### PR TITLE
[CU-86erf02v1] Fix broken GitHub dependency bot because it doesn't support new version Poetry

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2791,4 +2791,4 @@ mini = ["PyYAML"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.8,<3.13"
-content-hash = "66b9a996ce3fc09b1a5ca3f33d50dd91cd860c2b1f182b38f5a565df515b1ba8"
+content-hash = "05b2daa04a7581589e977ae8d8372ad26cb0d7cd322399a0af2e812ad160e303"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2792,4 +2792,4 @@ mini = ["PyYAML"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.8"
-content-hash = "43e470b8abee3baa541de3a5e26615ac5d1d2ce76fa25528f7153d660ea59022"
+content-hash = "0bf0fe9d5b95d6346708f2797ebe68fbb0dc638dc3abd810106e1f76423f87dd"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1134,7 +1134,6 @@ description = "An MkDocs plugin to create a list of contributors on the page. Th
 optional = false
 python-versions = "<4,>=3.8"
 groups = ["docs"]
-markers = "python_version < \"4\""
 files = [
     {file = "mkdocs_git_committers_plugin_2-2.4.1-py3-none-any.whl", hash = "sha256:ec9c1d81445606c471337d1c4a1782c643b7377077b545279dc18b86b7362c6d"},
     {file = "mkdocs_git_committers_plugin_2-2.4.1.tar.gz", hash = "sha256:ea1f80a79cedc42289e0b8e973276df04fb94f56e0ae3efc5385fb28547cf5cb"},
@@ -2791,5 +2790,5 @@ mini = ["PyYAML"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.8"
-content-hash = "0bf0fe9d5b95d6346708f2797ebe68fbb0dc638dc3abd810106e1f76423f87dd"
+python-versions = ">=3.8,<3.13"
+content-hash = "66b9a996ce3fc09b1a5ca3f33d50dd91cd860c2b1f182b38f5a565df515b1ba8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,12 +32,18 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.8,<3.13"
 dependencies = [
     "PyYAML (>=6.0)",
 ]
 
 [tool.poetry]
+name = "fake-api-server"
+version = "0.2.0"
+description = "🕸🤖👺 A Python tool to fake API server, e.g., RESTful API server, easily and humanly without any coding."
+authors = [
+    "Liu, Bryant <chi10211201@cycu.org.tw>",
+]
 packages = [
     { include = "fake_api_server/" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "fake-api-server"
-version = "0.3.0"
+version = "0.2.0"
 description = "🕸🤖👺 A Python tool to fake API server, e.g., RESTful API server, easily and humanly without any coding."
 authors = [
     { name = "Liu, Bryant", email = "chi10211201@cycu.org.tw" }
@@ -73,6 +73,9 @@ Changelog = "https://chisanan232.github.io/PyMock-Server/latest/release_note/"
 
 [project.scripts]
 mock = "fake_api_server.runner:run"
+
+[tool.poetry.group.dev]
+optional = true
 
 [tool.poetry.group.dev.dependencies]
 # Dependency for test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,8 +80,9 @@ Changelog = "https://chisanan232.github.io/PyMock-Server/latest/release_note/"
 [project.scripts]
 mock = "fake_api_server.runner:run"
 
-[tool.poetry.group.dev]
-optional = true
+# TODO: Let the dependencies for development to be optional
+#[tool.poetry.group.dev]
+#optional = true
 
 [tool.poetry.group.dev.dependencies]
 # Dependency for test


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

[//]: # (The summary what you did or your target.)
* ### Task summary:

    Fix broken GitHub dependency bot because it doesn't support new version Poetry.

[//]: # (The task ID in ClickUp [project: https://app.clickup.com/9018752317/v/f/90183126979/90182605225] which maps this change.)
* ### Task tickets:

    * Task ID: [CU-86erf02v1](https://app.clickup.com/t/86erf02v1).
    * Relative task IDs: N/A.

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    Issue refer: https://github.com/Chisanan232/PyFake-API-Server/actions/runs/13045648918
    Issue error message: https://github.com/Chisanan232/PyFake-API-Server/network/updates/955869942


[//]: # (What's the scope in project it would affect with your modify? For example, would it affect CI workflow? Or any feature usage? Please list all the items which may be affected.)
## _Effecting Scope_

* Fix error from GitHub dependency bot.


[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

* Let the dependency about development to be optional.
* Add necessary properties of Poetry configuration for GitHub dependency bot to parse.
