### PR TITLE
[CU-86erhgv81] Support run the fake server in background by CLI

### DIFF
--- a/.github/workflows/rw_poetry_run_test_with_multi_py_versions.yaml
+++ b/.github/workflows/rw_poetry_run_test_with_multi_py_versions.yaml
@@ -74,7 +74,7 @@ jobs:
         os: [ubuntu-latest,ubuntu-22.04,macos-latest,macos-13]
         exclude:
           - os: macos-13
-            python-version: 3.13
+            python-version: '3.13'
         test-path: ${{fromJson(inputs.all_test_items_paths)}}
       fail-fast: false    # Fix issue in GitHub Action: FailFast: cancelling since parallel instance has failed
 

--- a/.github/workflows/rw_poetry_run_test_with_multi_py_versions.yaml
+++ b/.github/workflows/rw_poetry_run_test_with_multi_py_versions.yaml
@@ -72,6 +72,9 @@ jobs:
       matrix:
         python-version: [3.9,'3.10','3.11','3.12','3.13']
         os: [ubuntu-latest,ubuntu-22.04,macos-latest,macos-13]
+        exclude:
+          - os: macos-13
+            python-version: 3.13
         test-path: ${{fromJson(inputs.all_test_items_paths)}}
       fail-fast: false    # Fix issue in GitHub Action: FailFast: cancelling since parallel instance has failed
 

--- a/.github/workflows/rw_poetry_run_test_with_multi_py_versions.yaml
+++ b/.github/workflows/rw_poetry_run_test_with_multi_py_versions.yaml
@@ -71,7 +71,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.9,'3.10','3.11','3.12','3.13']
-        os: [ubuntu-latest,ubuntu-22.04,macos-latest,macos-13]
+        os: [ubuntu-latest,ubuntu-22.04,macos-latest,macos-14]
 #        exclude:
 #          - os: macos-13
 #            python-version: '3.13'

--- a/.github/workflows/rw_poetry_run_test_with_multi_py_versions.yaml
+++ b/.github/workflows/rw_poetry_run_test_with_multi_py_versions.yaml
@@ -72,9 +72,9 @@ jobs:
       matrix:
         python-version: [3.9,'3.10','3.11','3.12','3.13']
         os: [ubuntu-latest,ubuntu-22.04,macos-latest,macos-13]
-        exclude:
-          - os: macos-13
-            python-version: '3.13'
+#        exclude:
+#          - os: macos-13
+#            python-version: '3.13'
         test-path: ${{fromJson(inputs.all_test_items_paths)}}
       fail-fast: false    # Fix issue in GitHub Action: FailFast: cancelling since parallel instance has failed
 

--- a/fake_api_server/command/rest_server/run/options.py
+++ b/fake_api_server/command/rest_server/run/options.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from fake_api_server.command._base.options import MetaCommandOption
 from fake_api_server.command.rest_server.option import BaseSubCommandRestServer
@@ -61,3 +61,19 @@ class LegLevel(BaseSubCmdRunOption):
     help_description: str = "The log level."
     default_value: str = "info"
     _options: List[str] = ["critical", "error", "warning", "info", "debug", "trace"]
+
+
+class DaemonizeProcess(BaseSubCmdRunOption):
+    cli_option: str = "-D, --daemon"
+    name: str = "daemon"
+    help_description: str = "Daemonize the process runs API server instance."
+    action: str = "store_true"
+    default_value: bool = False
+    option_value_type: Optional[type] = None
+
+
+class AccessLogFile(BaseSubCmdRunOption):
+    cli_option: str = "--access-log-file"
+    name: str = "access_log_file"
+    help_description: str = "The file which program would use to write the access log to for record."
+    default_value: str = "fake-api-server.log"

--- a/fake_api_server/model/command/rest_server/cmd_args.py
+++ b/fake_api_server/model/command/rest_server/cmd_args.py
@@ -48,6 +48,8 @@ class SubcmdRunArguments(ParserArguments):
     bind: str
     workers: int
     log_level: str
+    daemon: bool
+    access_log_file: str
 
     @classmethod
     def deserialize(cls, args: Namespace) -> "SubcmdRunArguments":
@@ -58,6 +60,8 @@ class SubcmdRunArguments(ParserArguments):
             bind=args.bind,
             workers=args.workers,
             log_level=args.log_level,
+            daemon=args.daemon,
+            access_log_file=args.access_log_file,
         )
 
 

--- a/fake_api_server/server/rest/sgi/_model.py
+++ b/fake_api_server/server/rest/sgi/_model.py
@@ -46,7 +46,7 @@ class Command:
         command_line = [self.entry_point, str(self.options), self.app_path]
         if self.options.daemon:
             self._daemonize(command_line)
-        logger.debug(f"command_line: {command_line}")
+        # logger.debug(f"command_line: {command_line}")
         return " ".join(command_line)
 
     def _daemonize(self, command_line: List[str]) -> None:

--- a/fake_api_server/server/rest/sgi/_model.py
+++ b/fake_api_server/server/rest/sgi/_model.py
@@ -44,6 +44,7 @@ class Command:
     def line(self) -> str:
         """:obj:`str`: Properties with only getter for a string value of command line with options."""
         command_line = [self.entry_point, str(self.options), self.app_path]
+        print(f"[DEBUG] self.options.daemon: {self.options.daemon}")
         if self.options.daemon:
             self._daemonize(command_line)
         return " ".join(command_line)

--- a/fake_api_server/server/rest/sgi/_model.py
+++ b/fake_api_server/server/rest/sgi/_model.py
@@ -66,5 +66,5 @@ class Command:
         # NOTE: wired bug. The server instance access log will print in command line output streaming even use *nohup*
         # runs.
         # CI refer: https://github.com/Chisanan232/PyFake-API-Server/actions/runs/13561351806
-        print(f"Command line for set up application by SGI tool: {self.line}")
+        # logger.debug(f"Command line for set up application by SGI tool: {self.line}")
         subprocess.run(self.line, shell=True)

--- a/fake_api_server/server/rest/sgi/_model.py
+++ b/fake_api_server/server/rest/sgi/_model.py
@@ -46,7 +46,6 @@ class Command:
         command_line = [self.entry_point, str(self.options), self.app_path]
         if self.options.daemon:
             self._daemonize(command_line)
-        # logger.debug(f"command_line: {command_line}")
         return " ".join(command_line)
 
     def _daemonize(self, command_line: List[str]) -> None:
@@ -64,5 +63,8 @@ class Command:
             None.
 
         """
-        logger.info(f"Command line for set up application by SGI tool: {self.line}")
+        # NOTE: wired bug. The server instance access log will print in command line output streaming even use *nohup*
+        # runs.
+        # CI refer: https://github.com/Chisanan232/PyFake-API-Server/actions/runs/13561351806
+        print(f"Command line for set up application by SGI tool: {self.line}")
         subprocess.run(self.line, shell=True)

--- a/fake_api_server/server/rest/sgi/_model.py
+++ b/fake_api_server/server/rest/sgi/_model.py
@@ -67,5 +67,5 @@ class Command:
         # runs.
         # CI refer: https://github.com/Chisanan232/PyFake-API-Server/actions/runs/13561351806
         command_line = self.line
-        logger.debug(f"Command line for set up application by SGI tool: {command_line}")
+        logger.info(f"Command line for set up application by SGI tool: {command_line}")
         subprocess.run(command_line, shell=True)

--- a/fake_api_server/server/rest/sgi/_model.py
+++ b/fake_api_server/server/rest/sgi/_model.py
@@ -67,5 +67,5 @@ class Command:
         # runs.
         # CI refer: https://github.com/Chisanan232/PyFake-API-Server/actions/runs/13561351806
         command_line = self.line
-        print(f"Command line for set up application by SGI tool: {command_line}")
+        logger.debug(f"Command line for set up application by SGI tool: {command_line}")
         subprocess.run(command_line, shell=True)

--- a/fake_api_server/server/rest/sgi/_model.py
+++ b/fake_api_server/server/rest/sgi/_model.py
@@ -66,5 +66,5 @@ class Command:
         # NOTE: wired bug. The server instance access log will print in command line output streaming even use *nohup*
         # runs.
         # CI refer: https://github.com/Chisanan232/PyFake-API-Server/actions/runs/13561351806
-        print(f"Command line for set up application by SGI tool: {self.line}")
+        logger.debug(f"Command line for set up application by SGI tool: {self.line}")
         subprocess.run(self.line, shell=True)

--- a/fake_api_server/server/rest/sgi/_model.py
+++ b/fake_api_server/server/rest/sgi/_model.py
@@ -13,6 +13,8 @@ class CommandOptions:
     bind: str
     workers: str
     log_level: str
+    daemon: bool
+    access_log_file: str
 
     def __str__(self):
         """Combine all command line options as one line which be concatenated by a one space string value `' '`.
@@ -41,7 +43,14 @@ class Command:
     @property
     def line(self) -> str:
         """:obj:`str`: Properties with only getter for a string value of command line with options."""
-        return " ".join([self.entry_point, str(self.options), self.app_path])
+        command_line = [self.entry_point, str(self.options), self.app_path]
+        if self.options.daemon:
+            self._daemonize(command_line)
+        return " ".join(command_line)
+
+    def _daemonize(self, command_line: List[str]) -> None:
+        command_line.insert(0, "nohup")
+        command_line.append(f"&> {self.options.access_log_file} &")
 
     @property
     def app_path(self) -> str:

--- a/fake_api_server/server/rest/sgi/_model.py
+++ b/fake_api_server/server/rest/sgi/_model.py
@@ -64,5 +64,5 @@ class Command:
             None.
 
         """
-        logger.debug(f"Command line for set up application by SGI tool: {self.line}")
+        print(f"Command line for set up application by SGI tool: {self.line}")
         subprocess.run(self.line, shell=True)

--- a/fake_api_server/server/rest/sgi/_model.py
+++ b/fake_api_server/server/rest/sgi/_model.py
@@ -66,5 +66,6 @@ class Command:
         # NOTE: wired bug. The server instance access log will print in command line output streaming even use *nohup*
         # runs.
         # CI refer: https://github.com/Chisanan232/PyFake-API-Server/actions/runs/13561351806
-        logger.debug(f"Command line for set up application by SGI tool: {self.line}")
-        subprocess.run(self.line, shell=True)
+        command_line = self.line
+        logger.debug(f"Command line for set up application by SGI tool: {command_line}")
+        subprocess.run(command_line, shell=True)

--- a/fake_api_server/server/rest/sgi/_model.py
+++ b/fake_api_server/server/rest/sgi/_model.py
@@ -64,5 +64,5 @@ class Command:
             None.
 
         """
-        print(f"Command line for set up application by SGI tool: {self.line}")
+        logger.info(f"Command line for set up application by SGI tool: {self.line}")
         subprocess.run(self.line, shell=True)

--- a/fake_api_server/server/rest/sgi/_model.py
+++ b/fake_api_server/server/rest/sgi/_model.py
@@ -66,5 +66,5 @@ class Command:
         # NOTE: wired bug. The server instance access log will print in command line output streaming even use *nohup*
         # runs.
         # CI refer: https://github.com/Chisanan232/PyFake-API-Server/actions/runs/13561351806
-        # logger.debug(f"Command line for set up application by SGI tool: {self.line}")
+        print(f"Command line for set up application by SGI tool: {self.line}")
         subprocess.run(self.line, shell=True)

--- a/fake_api_server/server/rest/sgi/_model.py
+++ b/fake_api_server/server/rest/sgi/_model.py
@@ -63,9 +63,6 @@ class Command:
             None.
 
         """
-        # NOTE: wired bug. The server instance access log will print in command line output streaming even use *nohup*
-        # runs.
-        # CI refer: https://github.com/Chisanan232/PyFake-API-Server/actions/runs/13561351806
         command_line = self.line
         logger.debug(f"Command line for set up application by SGI tool: {command_line}")
         subprocess.run(command_line, shell=True)

--- a/fake_api_server/server/rest/sgi/_model.py
+++ b/fake_api_server/server/rest/sgi/_model.py
@@ -46,6 +46,7 @@ class Command:
         command_line = [self.entry_point, str(self.options), self.app_path]
         if self.options.daemon:
             self._daemonize(command_line)
+        logger.debug(f"command_line: {command_line}")
         return " ".join(command_line)
 
     def _daemonize(self, command_line: List[str]) -> None:

--- a/fake_api_server/server/rest/sgi/_model.py
+++ b/fake_api_server/server/rest/sgi/_model.py
@@ -44,8 +44,7 @@ class Command:
     def line(self) -> str:
         """:obj:`str`: Properties with only getter for a string value of command line with options."""
         command_line = [self.entry_point, str(self.options), self.app_path]
-        print(f"[DEBUG] self.options.daemon: {self.options.daemon}")
-        if self.options.daemon:
+        if self.options.daemon is True:
             self._daemonize(command_line)
         return " ".join(command_line)
 
@@ -68,5 +67,5 @@ class Command:
         # runs.
         # CI refer: https://github.com/Chisanan232/PyFake-API-Server/actions/runs/13561351806
         command_line = self.line
-        logger.info(f"Command line for set up application by SGI tool: {command_line}")
+        print(f"Command line for set up application by SGI tool: {command_line}")
         subprocess.run(command_line, shell=True)

--- a/fake_api_server/server/rest/sgi/_model.py
+++ b/fake_api_server/server/rest/sgi/_model.py
@@ -51,7 +51,7 @@ class Command:
 
     def _daemonize(self, command_line: List[str]) -> None:
         command_line.insert(0, "nohup")
-        command_line.append(f"&> {self.options.access_log_file} &")
+        command_line.append(f"> {self.options.access_log_file} &")
 
     @property
     def app_path(self) -> str:

--- a/fake_api_server/server/rest/sgi/_model.py
+++ b/fake_api_server/server/rest/sgi/_model.py
@@ -50,7 +50,7 @@ class Command:
 
     def _daemonize(self, command_line: List[str]) -> None:
         command_line.insert(0, "nohup")
-        command_line.append(f"> {self.options.access_log_file} &")
+        command_line.append(f"> {self.options.access_log_file} 2>&1 &")
 
     @property
     def app_path(self) -> str:

--- a/fake_api_server/server/rest/sgi/cmd.py
+++ b/fake_api_server/server/rest/sgi/cmd.py
@@ -41,6 +41,8 @@ class BaseSGIServer(metaclass=ABCMeta):
                 bind=self.options.bind(address=parser_args.bind),
                 workers=self.options.workers(w=parser_args.workers),
                 log_level=self.options.log_level(level=parser_args.log_level),
+                daemon=parser_args.daemon,
+                access_log_file=parser_args.access_log_file,
             ),
         )
 

--- a/test/_values.py
+++ b/test/_values.py
@@ -698,7 +698,7 @@ _Bind_Host_And_Port: _Cmd_Option = _Cmd_Option(option_name="--bind", value="127.
 _Workers_Amount: _Cmd_Option = _Cmd_Option(option_name="--workers", value=3)
 _Log_Level: _Cmd_Option = _Cmd_Option(option_name="--log-level", value="info")
 _Daemon: _Cmd_Option = _Cmd_Option(option_name="--daemon", value=False)
-_Access_Log_File: _Cmd_Option = _Cmd_Option(option_name="--access-log-file", value="pytest-fake-api-server.log")
+_Access_Log_File: _Cmd_Option = _Cmd_Option(option_name="--access-log-file", value="./pytest-fake-api-server.log")
 
 # Test command line options
 _Test_SubCommand_Run: str = "run"

--- a/test/_values.py
+++ b/test/_values.py
@@ -697,6 +697,8 @@ _Cmd_Option = namedtuple("_Cmd_Option", ["option_name", "value"])
 _Bind_Host_And_Port: _Cmd_Option = _Cmd_Option(option_name="--bind", value="127.0.0.1:9672")
 _Workers_Amount: _Cmd_Option = _Cmd_Option(option_name="--workers", value=3)
 _Log_Level: _Cmd_Option = _Cmd_Option(option_name="--log-level", value="info")
+_Daemon: _Cmd_Option = _Cmd_Option(option_name="--daemon", value=False)
+_Access_Log_File: _Cmd_Option = _Cmd_Option(option_name="--access-log-file", value="pytest-fake-api-server.log")
 
 # Test command line options
 _Test_SubCommand_Run: str = "run"

--- a/test/system_test/_base.py
+++ b/test/system_test/_base.py
@@ -1,12 +1,9 @@
-import platform
 import re
 import subprocess
 import sys
 import threading
 import time
 from abc import ABCMeta, abstractmethod
-
-import pytest
 
 # isort: off
 from test._file_utils import yaml_factory
@@ -30,18 +27,18 @@ class CommandTestSpec(metaclass=ABCMeta):
     def options(self) -> str:
         pass
 
-    @pytest.mark.skipif(
-        (
-            platform.system() == "Linux"
-            and sys.version_info >= (3, 12)
-            or (
-                platform.system() == "Darwin"
-                and int((platform.mac_ver() or (15,))[0]) == 13
-                and sys.version_info >= (3, 13)
-            )
-        ),
-        reason="Wired bug about cannot run the program in background by *nohup* correctly.",
-    )
+    # @pytest.mark.skipif(
+    #     (
+    #         platform.system() == "Linux"
+    #         and sys.version_info >= (3, 12)
+    #         or (
+    #             platform.system() == "Darwin"
+    #             and float((platform.mac_ver() or (15,))[0]) >= 13.0
+    #             and sys.version_info >= (3, 13)
+    #         )
+    #     ),
+    #     reason="Wired bug about cannot run the program in background by *nohup* correctly.",
+    # )
     @run_test.with_file(yaml_factory)
     def test_command(self) -> None:
         try:
@@ -79,6 +76,7 @@ class CommandTestSpec(metaclass=ABCMeta):
 
     @classmethod
     def _should_contains_chars_in_result(cls, target: str, expected_char, translate: bool = True) -> None:
+        # print(f"[DEBUG _should_contains_chars_in_result] target: {target}")
         if translate:
             assert re.search(re.escape(expected_char), target, re.IGNORECASE)
         else:
@@ -86,6 +84,7 @@ class CommandTestSpec(metaclass=ABCMeta):
 
     @classmethod
     def _should_not_contains_chars_in_result(cls, target: str, expected_char, translate: bool = True) -> None:
+        # print(f"[DEBUG _should_not_contains_chars_in_result] target: {target}")
         if translate:
             assert not re.search(re.escape(expected_char), target, re.IGNORECASE)
         else:

--- a/test/system_test/_base.py
+++ b/test/system_test/_base.py
@@ -71,7 +71,6 @@ class CommandTestSpec(metaclass=ABCMeta):
 
     @classmethod
     def _should_not_contains_chars_in_result(cls, target: str, expected_char, translate: bool = True) -> None:
-        print(f"[DEBUG] in _should_not_contains_chars_in_result target: {target}")
         if translate:
             assert not re.search(re.escape(expected_char), target, re.IGNORECASE)
         else:

--- a/test/system_test/_base.py
+++ b/test/system_test/_base.py
@@ -1,0 +1,84 @@
+import re
+import subprocess
+import sys
+import threading
+import time
+from abc import ABC, ABCMeta, abstractmethod
+
+# isort: off
+from test._file_utils import yaml_factory
+from test._spec import run_test
+from test._utils import Capturing
+
+# isort: on
+
+
+class CommandTestSpec(metaclass=ABCMeta):
+    Server_Running_Entry_Point: str = "fake_api_server/runner.py"
+    Terminate_Command_Running_When_Sniff_IP_Info: bool = True
+    Wait_Time_Before_Verify: int = 0
+
+    @property
+    def command_line(self) -> str:
+        return f"python3 {self.Server_Running_Entry_Point} {self.options}"
+
+    @property
+    @abstractmethod
+    def options(self) -> str:
+        pass
+
+    @run_test.with_file(yaml_factory)
+    def test_command(self) -> None:
+        try:
+            with Capturing() as mock_server_output:
+                self._run_as_thread(target=self._run_command_line)
+            time.sleep(self.Wait_Time_Before_Verify)
+            self._verify_running_output(" ".join(mock_server_output).replace("\n", "").replace("  ", ""))
+        finally:
+            self._do_finally()
+
+    def _run_command_line(self) -> None:
+        cmd_ps = subprocess.Popen(self.command_line, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        self._read_streaming_output(cmd_ps)
+
+    def _read_streaming_output(self, cmd_ps: subprocess.Popen) -> None:
+        for line in iter(lambda: cmd_ps.stdout.readline(), b""):  # type: ignore
+            sys.stdout.write(line.decode("utf-8"))
+            if self.Terminate_Command_Running_When_Sniff_IP_Info and re.search(
+                r"[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}", line.decode("utf-8")
+            ):
+                break
+
+    @abstractmethod
+    def _verify_running_output(self, cmd_running_result: str) -> None:
+        pass
+
+    @classmethod
+    def _run_as_thread(cls, target) -> None:
+        run_cmd_thread = threading.Thread(target=target)
+        run_cmd_thread.daemon = True
+        run_cmd_thread.run()
+
+    def _do_finally(self) -> None:
+        pass
+
+    @classmethod
+    def _should_contains_chars_in_result(cls, target: str, expected_char, translate: bool = True) -> None:
+        if translate:
+            assert re.search(re.escape(expected_char), target, re.IGNORECASE)
+        else:
+            assert re.search(expected_char, target, re.IGNORECASE)
+
+    @classmethod
+    def _should_not_contains_chars_in_result(cls, target: str, expected_char, translate: bool = True) -> None:
+        if translate:
+            assert not re.search(re.escape(expected_char), target, re.IGNORECASE)
+        else:
+            assert not re.search(expected_char, target, re.IGNORECASE)
+
+
+class SubCmdRestServerTestSuite(CommandTestSpec, ABC):
+
+    @property
+    def command_line(self) -> str:
+        return f"python3 {self.Server_Running_Entry_Point} rest-server {self.options}"

--- a/test/system_test/_base.py
+++ b/test/system_test/_base.py
@@ -71,7 +71,6 @@ class CommandTestSpec(metaclass=ABCMeta):
 
     @classmethod
     def _should_not_contains_chars_in_result(cls, target: str, expected_char, translate: bool = True) -> None:
-        print(f"[DEBUG] target: {target}")
         if translate:
             assert not re.search(re.escape(expected_char), target, re.IGNORECASE)
         else:

--- a/test/system_test/_base.py
+++ b/test/system_test/_base.py
@@ -71,6 +71,7 @@ class CommandTestSpec(metaclass=ABCMeta):
 
     @classmethod
     def _should_not_contains_chars_in_result(cls, target: str, expected_char, translate: bool = True) -> None:
+        print(f"[DEBUG] target: {target}")
         if translate:
             assert not re.search(re.escape(expected_char), target, re.IGNORECASE)
         else:

--- a/test/system_test/_base.py
+++ b/test/system_test/_base.py
@@ -71,6 +71,7 @@ class CommandTestSpec(metaclass=ABCMeta):
 
     @classmethod
     def _should_not_contains_chars_in_result(cls, target: str, expected_char, translate: bool = True) -> None:
+        print(f"[DEBUG] in _should_not_contains_chars_in_result target: {target}")
         if translate:
             assert not re.search(re.escape(expected_char), target, re.IGNORECASE)
         else:

--- a/test/system_test/_base.py
+++ b/test/system_test/_base.py
@@ -34,7 +34,11 @@ class CommandTestSpec(metaclass=ABCMeta):
         (
             platform.system() == "Linux"
             and sys.version_info >= (3, 12)
-            or (platform.system() == "Darwin" and sys.version_info >= (3, 13))
+            or (
+                platform.system() == "Darwin"
+                and int((platform.mac_ver() or (15,))[0]) == 13
+                and sys.version_info >= (3, 13)
+            )
         ),
         reason="Wired bug about cannot run the program in background by *nohup* correctly.",
     )

--- a/test/system_test/_base.py
+++ b/test/system_test/_base.py
@@ -1,9 +1,12 @@
+import platform
 import re
 import subprocess
 import sys
 import threading
 import time
 from abc import ABCMeta, abstractmethod
+
+import pytest
 
 # isort: off
 from test._file_utils import yaml_factory
@@ -27,6 +30,14 @@ class CommandTestSpec(metaclass=ABCMeta):
     def options(self) -> str:
         pass
 
+    @pytest.mark.skipif(
+        (
+            platform.system() == "Linux"
+            and sys.version_info >= (3, 12)
+            or (platform.system() == "Darwin" and sys.version_info >= (3, 13))
+        ),
+        reason="Wired bug about cannot run the program in background by *nohup* correctly.",
+    )
     @run_test.with_file(yaml_factory)
     def test_command(self) -> None:
         try:

--- a/test/system_test/_base.py
+++ b/test/system_test/_base.py
@@ -27,18 +27,6 @@ class CommandTestSpec(metaclass=ABCMeta):
     def options(self) -> str:
         pass
 
-    # @pytest.mark.skipif(
-    #     (
-    #         platform.system() == "Linux"
-    #         and sys.version_info >= (3, 12)
-    #         or (
-    #             platform.system() == "Darwin"
-    #             and float((platform.mac_ver() or (15,))[0]) >= 13.0
-    #             and sys.version_info >= (3, 13)
-    #         )
-    #     ),
-    #     reason="Wired bug about cannot run the program in background by *nohup* correctly.",
-    # )
     @run_test.with_file(yaml_factory)
     def test_command(self) -> None:
         try:
@@ -76,7 +64,6 @@ class CommandTestSpec(metaclass=ABCMeta):
 
     @classmethod
     def _should_contains_chars_in_result(cls, target: str, expected_char, translate: bool = True) -> None:
-        # print(f"[DEBUG _should_contains_chars_in_result] target: {target}")
         if translate:
             assert re.search(re.escape(expected_char), target, re.IGNORECASE)
         else:
@@ -84,7 +71,6 @@ class CommandTestSpec(metaclass=ABCMeta):
 
     @classmethod
     def _should_not_contains_chars_in_result(cls, target: str, expected_char, translate: bool = True) -> None:
-        # print(f"[DEBUG _should_not_contains_chars_in_result] target: {target}")
         if translate:
             assert not re.search(re.escape(expected_char), target, re.IGNORECASE)
         else:

--- a/test/system_test/_base.py
+++ b/test/system_test/_base.py
@@ -3,7 +3,7 @@ import subprocess
 import sys
 import threading
 import time
-from abc import ABC, ABCMeta, abstractmethod
+from abc import ABCMeta, abstractmethod
 
 # isort: off
 from test._file_utils import yaml_factory
@@ -75,10 +75,3 @@ class CommandTestSpec(metaclass=ABCMeta):
             assert not re.search(re.escape(expected_char), target, re.IGNORECASE)
         else:
             assert not re.search(expected_char, target, re.IGNORECASE)
-
-
-class SubCmdRestServerTestSuite(CommandTestSpec, ABC):
-
-    @property
-    def command_line(self) -> str:
-        return f"python3 {self.Server_Running_Entry_Point} rest-server {self.options}"

--- a/test/system_test/rest_server/_base.py
+++ b/test/system_test/rest_server/_base.py
@@ -1,0 +1,13 @@
+from abc import ABC
+
+# isort: off
+from test.system_test._base import CommandTestSpec
+
+# isort: on
+
+
+class SubCmdRestServerTestSuite(CommandTestSpec, ABC):
+
+    @property
+    def command_line(self) -> str:
+        return f"python3 {self.Server_Running_Entry_Point} rest-server {self.options}"

--- a/test/system_test/rest_server/run_cmd_init.py
+++ b/test/system_test/rest_server/run_cmd_init.py
@@ -1,9 +1,8 @@
-from test.system_test._base import SubCmdRestServerTestSuite
-
 # isort: off
 from test._values import (
     SubCommand,
 )
+from test.system_test.rest_server._base import SubCmdRestServerTestSuite
 
 # isort: on
 

--- a/test/system_test/rest_server/run_cmd_init.py
+++ b/test/system_test/rest_server/run_cmd_init.py
@@ -1,4 +1,4 @@
-from ._base import SubCmdRestServerTestSuite
+from test.system_test._base import SubCmdRestServerTestSuite
 
 # isort: off
 from test._values import (

--- a/test/system_test/rest_server/run_cmd_run.py
+++ b/test/system_test/rest_server/run_cmd_run.py
@@ -5,7 +5,6 @@ import re
 import subprocess
 from abc import ABC, abstractmethod
 from pathlib import Path
-from test.system_test._base import SubCmdRestServerTestSuite
 from typing import Callable
 
 # isort: off
@@ -18,6 +17,7 @@ from test._values import (
     _YouTube_Home_Value,
     _Access_Log_File,
 )
+from test.system_test.rest_server._base import SubCmdRestServerTestSuite
 
 # isort: on
 

--- a/test/system_test/rest_server/run_cmd_run.py
+++ b/test/system_test/rest_server/run_cmd_run.py
@@ -84,8 +84,13 @@ class RunFakeServerTestSpec(SubCmdRestServerTestSuite, ABC):
             shell=True,
             stdout=subprocess.PIPE,
         )
-        assert curl_google_ps.stdout
-        resp = curl_google_ps.stdout.readlines()[0]
+        curl_stdout = curl_google_ps.stdout
+        assert curl_stdout
+        logger.info(f"[DEBUG] curl_stdout")
+        curl_result_output = curl_stdout.readlines()
+        assert curl_result_output
+        logger.info(f"[DEBUG] curl_result_output")
+        resp = curl_result_output[0]
         resp_content = json.loads(resp.decode("utf-8"))["content"] if resp_is_json_format else resp.decode("utf-8")
         assert re.search(re.escape(expected_resp_content), resp_content, re.IGNORECASE)
 

--- a/test/system_test/rest_server/run_cmd_run.py
+++ b/test/system_test/rest_server/run_cmd_run.py
@@ -86,9 +86,7 @@ class RunFakeServerTestSpec(SubCmdRestServerTestSuite, ABC):
             stdout=subprocess.PIPE,
         )
         assert curl_google_ps.stdout
-        readlines = curl_google_ps.stdout.readlines()
-        print(f"[DEBUG] readlines: {readlines}")
-        resp = readlines[0]
+        resp = curl_google_ps.stdout.readlines()[0]
         resp_content = json.loads(resp.decode("utf-8"))["content"] if resp_is_json_format else resp.decode("utf-8")
         assert re.search(re.escape(expected_resp_content), resp_content, re.IGNORECASE)
 

--- a/test/system_test/rest_server/run_cmd_run.py
+++ b/test/system_test/rest_server/run_cmd_run.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import os
 import re
 import subprocess
@@ -154,7 +153,7 @@ class RunFakeServerAsDaemonTestSpec(RunFakeServerTestSpec, ABC):
     def _do_finally(self) -> None:
         with open(_Access_Log_File.value, "r") as file:
             content = file.read()
-            logging.debug(f"Server access log: {content}")
+            print(f"[DEBUG] Server access log: {content}")
         os.remove(_Access_Log_File.value)
         super()._do_finally()
 

--- a/test/system_test/rest_server/run_cmd_run.py
+++ b/test/system_test/rest_server/run_cmd_run.py
@@ -5,9 +5,8 @@ import re
 import subprocess
 from abc import ABC, abstractmethod
 from pathlib import Path
+from test.system_test._base import SubCmdRestServerTestSuite
 from typing import Callable
-
-from ._base import SubCmdRestServerTestSuite
 
 # isort: off
 from test._file_utils import MockAPI_Config_Yaml_Path

--- a/test/system_test/rest_server/run_cmd_run.py
+++ b/test/system_test/rest_server/run_cmd_run.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import os
-import platform
 import re
 import subprocess
 from abc import ABC, abstractmethod
@@ -152,10 +151,7 @@ class TestWithAuto(FastAPITestSuite):
 
 
 class RunFakeServerAsDaemonTestSpec(RunFakeServerTestSpec, ABC):
-    if platform.system() == "Linux":
-        Wait_Time_Before_Verify: int = 5
-    else:
-        Wait_Time_Before_Verify: int = 2  # type: ignore[no-redef]
+    Wait_Time_Before_Verify: int = 2
 
     def _do_finally(self) -> None:
         with open(_Access_Log_File.value, "r") as file:

--- a/test/system_test/rest_server/run_cmd_run.py
+++ b/test/system_test/rest_server/run_cmd_run.py
@@ -1,5 +1,6 @@
 import json
 import os
+import platform
 import re
 import subprocess
 from abc import ABC, abstractmethod
@@ -148,7 +149,10 @@ class TestWithAuto(FastAPITestSuite):
 
 
 class RunFakeServerAsDaemonTestSpec(RunFakeServerTestSpec, ABC):
-    Wait_Time_Before_Verify: int = 2
+    if platform.system() == "Linux":
+        Wait_Time_Before_Verify: int = 5
+    else:
+        Wait_Time_Before_Verify: int = 2  # type: ignore[no-redef]
 
     def _do_finally(self) -> None:
         with open(_Access_Log_File.value, "r") as file:

--- a/test/system_test/rest_server/run_cmd_run.py
+++ b/test/system_test/rest_server/run_cmd_run.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import platform
 import re
@@ -20,6 +21,8 @@ from test._values import (
 from test.system_test.rest_server._base import SubCmdRestServerTestSuite
 
 # isort: on
+
+logger = logging.getLogger(__name__)
 
 
 class TestSubCommandRun(SubCmdRestServerTestSuite):
@@ -159,7 +162,7 @@ class RunFakeServerAsDaemonTestSpec(RunFakeServerTestSpec, ABC):
     def _do_finally(self) -> None:
         with open(_Access_Log_File.value, "r") as file:
             content = file.read()
-            print(f"[DEBUG] Server access log: {content}")
+            logger.debug(f"Server access log: {content}")
         os.remove(_Access_Log_File.value)
         super()._do_finally()
 

--- a/test/system_test/rest_server/run_cmd_run.py
+++ b/test/system_test/rest_server/run_cmd_run.py
@@ -170,6 +170,7 @@ class RunFakeServerAsDaemonTestSpec(RunFakeServerTestSpec, ABC):
         assert Path(_Access_Log_File.value).exists()
         with open(_Access_Log_File.value, "r") as file:
             log_file_content = file.read()
+        self._check_server_running_access_log(log_file_content, contains=True)
         super()._verify_running_output(log_file_content)
 
 

--- a/test/system_test/rest_server/run_cmd_run.py
+++ b/test/system_test/rest_server/run_cmd_run.py
@@ -83,7 +83,9 @@ class RunFakeServerTestSpec(SubCmdRestServerTestSuite, ABC):
             stdout=subprocess.PIPE,
         )
         assert curl_google_ps.stdout
-        resp = curl_google_ps.stdout.readlines()[0]
+        readlines = curl_google_ps.stdout.readlines()
+        print(f"[DEBUG] readlines: {readlines}")
+        resp = readlines[0]
         resp_content = json.loads(resp.decode("utf-8"))["content"] if resp_is_json_format else resp.decode("utf-8")
         assert re.search(re.escape(expected_resp_content), resp_content, re.IGNORECASE)
 

--- a/test/system_test/rest_server/run_cmd_run.py
+++ b/test/system_test/rest_server/run_cmd_run.py
@@ -86,10 +86,8 @@ class RunFakeServerTestSpec(SubCmdRestServerTestSuite, ABC):
         )
         curl_stdout = curl_google_ps.stdout
         assert curl_stdout
-        logger.info(f"[DEBUG] curl_stdout")
         curl_result_output = curl_stdout.readlines()
         assert curl_result_output
-        logger.info(f"[DEBUG] curl_result_output")
         resp = curl_result_output[0]
         resp_content = json.loads(resp.decode("utf-8"))["content"] if resp_is_json_format else resp.decode("utf-8")
         assert re.search(re.escape(expected_resp_content), resp_content, re.IGNORECASE)

--- a/test/system_test/rest_server/run_cmd_sample.py
+++ b/test/system_test/rest_server/run_cmd_sample.py
@@ -11,7 +11,7 @@ from fake_api_server.model.command.rest_server._sample import (
 )
 
 # isort: off
-from test.system_test._base import SubCmdRestServerTestSuite
+from test.system_test.rest_server._base import SubCmdRestServerTestSuite
 
 # isort: on
 

--- a/test/system_test/rest_server/run_cmd_sample.py
+++ b/test/system_test/rest_server/run_cmd_sample.py
@@ -11,7 +11,7 @@ from fake_api_server.model.command.rest_server._sample import (
 )
 
 # isort: off
-from ._base import SubCmdRestServerTestSuite
+from test.system_test._base import SubCmdRestServerTestSuite
 
 # isort: on
 

--- a/test/system_test/run_cmd.py
+++ b/test/system_test/run_cmd.py
@@ -204,7 +204,7 @@ class TestGenerateSampleConfiguration(SubCmdRestServerTestSuite):
         assert config_data == Sample_Config_Value
 
 
-class RunMockApplicationTestSpec(SubCmdRestServerTestSuite, ABC):
+class RunFakeServerTestSpec(SubCmdRestServerTestSuite, ABC):
     def _verify_running_output(self, cmd_running_result: str) -> None:
         self._verify_apis()
 
@@ -253,7 +253,7 @@ class RunMockApplicationTestSpec(SubCmdRestServerTestSuite, ABC):
         assert re.search(re.escape(expected_resp_content), resp_content, re.IGNORECASE)
 
 
-class TestRunMockApplicationWithFlask(RunMockApplicationTestSpec):
+class TestRunFakeServerWithFlask(RunFakeServerTestSpec):
     @property
     def options(self) -> str:
         return f"run --app-type flask --bind {_Bind_Host_And_Port.value} --config {MockAPI_Config_Yaml_Path}"
@@ -267,7 +267,7 @@ class TestRunMockApplicationWithFlask(RunMockApplicationTestSpec):
         super()._verify_running_output(cmd_running_result)
 
 
-class TestRunMockApplicationWithFastAPI(RunMockApplicationTestSpec):
+class TestRunFakeServerWithFastAPI(RunFakeServerTestSpec):
     @property
     def options(self) -> str:
         return f"run --app-type fastapi --bind {_Bind_Host_And_Port.value} --config {MockAPI_Config_Yaml_Path}"
@@ -285,7 +285,7 @@ class TestRunMockApplicationWithFastAPI(RunMockApplicationTestSpec):
         super()._verify_running_output(cmd_running_result)
 
 
-class TestRunMockApplicationWithAuto(RunMockApplicationTestSpec):
+class TestRunFakeServerWithAuto(RunFakeServerTestSpec):
     @property
     def options(self) -> str:
         return f"run --app-type auto --bind {_Bind_Host_And_Port.value} --config {MockAPI_Config_Yaml_Path}"

--- a/test/system_test/run_cmd.py
+++ b/test/system_test/run_cmd.py
@@ -3,10 +3,7 @@ import logging
 import os
 import re
 import subprocess
-import sys
-import threading
-import time
-from abc import ABC, ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Callable, Optional
 
@@ -19,10 +16,10 @@ from fake_api_server.model.command.rest_server._sample import (
     Sample_Config_Value,
 )
 
+from ._base import SubCmdRestServerTestSuite
+
 # isort: off
-from test._file_utils import MockAPI_Config_Yaml_Path, yaml_factory
-from test._spec import run_test
-from test._utils import Capturing
+from test._file_utils import MockAPI_Config_Yaml_Path
 from test._values import (
     SubCommand,
     _Base_URL,
@@ -34,77 +31,6 @@ from test._values import (
 )
 
 # isort: on
-
-
-class CommandTestSpec(metaclass=ABCMeta):
-    Server_Running_Entry_Point: str = "fake_api_server/runner.py"
-    Terminate_Command_Running_When_Sniff_IP_Info: bool = True
-    Wait_Time_Before_Verify: int = 0
-
-    @property
-    def command_line(self) -> str:
-        return f"python3 {self.Server_Running_Entry_Point} {self.options}"
-
-    @property
-    @abstractmethod
-    def options(self) -> str:
-        pass
-
-    @run_test.with_file(yaml_factory)
-    def test_command(self) -> None:
-        try:
-            with Capturing() as mock_server_output:
-                self._run_as_thread(target=self._run_command_line)
-            time.sleep(self.Wait_Time_Before_Verify)
-            self._verify_running_output(" ".join(mock_server_output).replace("\n", "").replace("  ", ""))
-        finally:
-            self._do_finally()
-
-    def _run_command_line(self) -> None:
-        cmd_ps = subprocess.Popen(self.command_line, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-        self._read_streaming_output(cmd_ps)
-
-    def _read_streaming_output(self, cmd_ps: subprocess.Popen) -> None:
-        for line in iter(lambda: cmd_ps.stdout.readline(), b""):  # type: ignore
-            sys.stdout.write(line.decode("utf-8"))
-            if self.Terminate_Command_Running_When_Sniff_IP_Info and re.search(
-                r"[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}", line.decode("utf-8")
-            ):
-                break
-
-    @abstractmethod
-    def _verify_running_output(self, cmd_running_result: str) -> None:
-        pass
-
-    @classmethod
-    def _run_as_thread(cls, target) -> None:
-        run_cmd_thread = threading.Thread(target=target)
-        run_cmd_thread.daemon = True
-        run_cmd_thread.run()
-
-    def _do_finally(self) -> None:
-        pass
-
-    @classmethod
-    def _should_contains_chars_in_result(cls, target: str, expected_char, translate: bool = True) -> None:
-        if translate:
-            assert re.search(re.escape(expected_char), target, re.IGNORECASE)
-        else:
-            assert re.search(expected_char, target, re.IGNORECASE)
-
-    @classmethod
-    def _should_not_contains_chars_in_result(cls, target: str, expected_char, translate: bool = True) -> None:
-        if translate:
-            assert not re.search(re.escape(expected_char), target, re.IGNORECASE)
-        else:
-            assert not re.search(expected_char, target, re.IGNORECASE)
-
-
-class SubCmdRestServerTestSuite(CommandTestSpec, ABC):
-
-    @property
-    def command_line(self) -> str:
-        return f"python3 {self.Server_Running_Entry_Point} rest-server {self.options}"
 
 
 class TestSubCmdRestServerWithoutAnyCmdArgs(SubCmdRestServerTestSuite):

--- a/test/system_test/run_cmd_init.py
+++ b/test/system_test/run_cmd_init.py
@@ -1,0 +1,30 @@
+from ._base import SubCmdRestServerTestSuite
+
+# isort: off
+from test._values import (
+    SubCommand,
+)
+
+# isort: on
+
+
+class TestSubCmdRestServerWithoutAnyCmdArgs(SubCmdRestServerTestSuite):
+    Terminate_Command_Running_When_Sniff_IP_Info: bool = False
+
+    @property
+    def options(self) -> str:
+        return ""
+
+    def _verify_running_output(self, cmd_running_result: str) -> None:
+        self._should_contains_chars_in_result(
+            cmd_running_result, "warn: please operate on this command with one more subcommand line you need"
+        )
+        self._should_contains_chars_in_result(cmd_running_result, "fake rest-server [-h]")
+        self._should_contains_chars_in_result(cmd_running_result, "-h, --help")
+        self._should_contains_chars_in_result(cmd_running_result, "API server subcommands:")
+        self._should_contains_chars_in_result(cmd_running_result, SubCommand.Pull)
+        self._should_contains_chars_in_result(cmd_running_result, SubCommand.Run)
+        self._should_contains_chars_in_result(cmd_running_result, SubCommand.Check)
+        self._should_contains_chars_in_result(cmd_running_result, SubCommand.Add)
+        self._should_contains_chars_in_result(cmd_running_result, SubCommand.Get)
+        self._should_contains_chars_in_result(cmd_running_result, SubCommand.Sample)

--- a/test/system_test/run_cmd_run.py
+++ b/test/system_test/run_cmd_run.py
@@ -93,7 +93,7 @@ class RunFakeServerTestSpec(SubCmdRestServerTestSuite, ABC):
         pass
 
 
-class BaseFakeServerByFlaskTestSuite(RunFakeServerTestSpec, ABC):
+class FlaskTestSuite(RunFakeServerTestSpec, ABC):
     def _do_finally(self) -> None:
         subprocess.run("pkill -f gunicorn", shell=True)
 
@@ -105,7 +105,7 @@ class BaseFakeServerByFlaskTestSuite(RunFakeServerTestSpec, ABC):
         check_callback(cmd_running_result, f"Listening at: http://{_Bind_Host_And_Port.value}")
 
 
-class BaseFakeServerByFastAPITestSuite(RunFakeServerTestSpec, ABC):
+class FastAPITestSuite(RunFakeServerTestSpec, ABC):
     def _do_finally(self) -> None:
         subprocess.run("pkill -f uvicorn", shell=True)
 
@@ -119,7 +119,7 @@ class BaseFakeServerByFastAPITestSuite(RunFakeServerTestSpec, ABC):
         check_callback(cmd_running_result, f"Uvicorn running on http://{_Bind_Host_And_Port.value}")
 
 
-class TestRunFakeServerWithFlask(BaseFakeServerByFlaskTestSuite):
+class TestWithFlask(FlaskTestSuite):
     @property
     def options(self) -> str:
         return f"run --app-type flask --bind {_Bind_Host_And_Port.value} --config {MockAPI_Config_Yaml_Path}"
@@ -129,7 +129,7 @@ class TestRunFakeServerWithFlask(BaseFakeServerByFlaskTestSuite):
         super()._verify_running_output(cmd_running_result)
 
 
-class TestRunFakeServerWithFastAPI(BaseFakeServerByFastAPITestSuite):
+class TestWithFastAPI(FastAPITestSuite):
     @property
     def options(self) -> str:
         return f"run --app-type fastapi --bind {_Bind_Host_And_Port.value} --config {MockAPI_Config_Yaml_Path}"
@@ -139,7 +139,7 @@ class TestRunFakeServerWithFastAPI(BaseFakeServerByFastAPITestSuite):
         super()._verify_running_output(cmd_running_result)
 
 
-class TestRunFakeServerWithAuto(BaseFakeServerByFastAPITestSuite):
+class TestWithAuto(FastAPITestSuite):
     @property
     def options(self) -> str:
         return f"run --app-type auto --bind {_Bind_Host_And_Port.value} --config {MockAPI_Config_Yaml_Path}"
@@ -149,7 +149,7 @@ class TestRunFakeServerWithAuto(BaseFakeServerByFastAPITestSuite):
         super()._verify_running_output(cmd_running_result)
 
 
-class _BaseRunFakeServerWithFlaskByDaemonTestSuite(BaseFakeServerByFlaskTestSuite, ABC):
+class _BaseFlaskAsDaemonTestSuite(FlaskTestSuite, ABC):
     Wait_Time_Before_Verify: int = 2
 
     def _do_finally(self) -> None:
@@ -167,7 +167,7 @@ class _BaseRunFakeServerWithFlaskByDaemonTestSuite(BaseFakeServerByFlaskTestSuit
         super()._verify_running_output(log_file_content)
 
 
-class _BaseRunFakeServerWithFastAPIByDaemonTestSuite(BaseFakeServerByFastAPITestSuite, ABC):
+class _BaseFastAPIAsDaemonTestSuite(FastAPITestSuite, ABC):
     Wait_Time_Before_Verify: int = 2
 
     def _do_finally(self) -> None:
@@ -185,19 +185,19 @@ class _BaseRunFakeServerWithFastAPIByDaemonTestSuite(BaseFakeServerByFastAPITest
         super()._verify_running_output(log_file_content)
 
 
-class TestRunFakeServerWithFlaskByDaemon(_BaseRunFakeServerWithFlaskByDaemonTestSuite):
+class TestWithFlaskAsDaemon(_BaseFlaskAsDaemonTestSuite):
     @property
     def options(self) -> str:
         return f"run --app-type flask --bind {_Bind_Host_And_Port.value} --config {MockAPI_Config_Yaml_Path} --config {MockAPI_Config_Yaml_Path} --access-log-file {_Access_Log_File.value} --daemon"
 
 
-class TestRunFakeServerWithFastAPIByDaemon(_BaseRunFakeServerWithFastAPIByDaemonTestSuite):
+class TestWithFastAPIAsDaemon(_BaseFastAPIAsDaemonTestSuite):
     @property
     def options(self) -> str:
         return f"run --app-type fastapi --bind {_Bind_Host_And_Port.value} --config {MockAPI_Config_Yaml_Path} --config {MockAPI_Config_Yaml_Path} --access-log-file {_Access_Log_File.value} --daemon"
 
 
-class TestRunFakeServerWithAutoByDaemon(_BaseRunFakeServerWithFastAPIByDaemonTestSuite):
+class TestWithAutoAsDaemon(_BaseFastAPIAsDaemonTestSuite):
     @property
     def options(self) -> str:
         return f"run --app-type auto --bind {_Bind_Host_And_Port.value} --config {MockAPI_Config_Yaml_Path} --access-log-file {_Access_Log_File.value} --daemon"

--- a/test/system_test/run_cmd_run.py
+++ b/test/system_test/run_cmd_run.py
@@ -5,23 +5,13 @@ import re
 import subprocess
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Callable, Optional
-
-import pytest
-
-from fake_api_server._utils.file.operation import YAML
-from fake_api_server.model.api_config.apis import ResponseStrategy
-from fake_api_server.model.command.rest_server._sample import (
-    Mocked_APIs,
-    Sample_Config_Value,
-)
+from typing import Callable
 
 from ._base import SubCmdRestServerTestSuite
 
 # isort: off
 from test._file_utils import MockAPI_Config_Yaml_Path
 from test._values import (
-    SubCommand,
     _Base_URL,
     _Bind_Host_And_Port,
     _Google_Home_Value,
@@ -31,28 +21,6 @@ from test._values import (
 )
 
 # isort: on
-
-
-class TestSubCmdRestServerWithoutAnyCmdArgs(SubCmdRestServerTestSuite):
-    Terminate_Command_Running_When_Sniff_IP_Info: bool = False
-
-    @property
-    def options(self) -> str:
-        return ""
-
-    def _verify_running_output(self, cmd_running_result: str) -> None:
-        self._should_contains_chars_in_result(
-            cmd_running_result, "warn: please operate on this command with one more subcommand line you need"
-        )
-        self._should_contains_chars_in_result(cmd_running_result, "fake rest-server [-h]")
-        self._should_contains_chars_in_result(cmd_running_result, "-h, --help")
-        self._should_contains_chars_in_result(cmd_running_result, "API server subcommands:")
-        self._should_contains_chars_in_result(cmd_running_result, SubCommand.Pull)
-        self._should_contains_chars_in_result(cmd_running_result, SubCommand.Run)
-        self._should_contains_chars_in_result(cmd_running_result, SubCommand.Check)
-        self._should_contains_chars_in_result(cmd_running_result, SubCommand.Add)
-        self._should_contains_chars_in_result(cmd_running_result, SubCommand.Get)
-        self._should_contains_chars_in_result(cmd_running_result, SubCommand.Sample)
 
 
 class TestSubCommandRun(SubCmdRestServerTestSuite):
@@ -70,77 +38,6 @@ class TestSubCommandRun(SubCmdRestServerTestSuite):
         self._should_contains_chars_in_result(cmd_running_result, "-b BIND, --bind BIND")
         self._should_contains_chars_in_result(cmd_running_result, "-w WORKERS, --workers WORKERS")
         self._should_contains_chars_in_result(cmd_running_result, "--log-level LOG_LEVEL")
-
-
-class TestSubCommandSample(SubCmdRestServerTestSuite):
-    Terminate_Command_Running_When_Sniff_IP_Info: bool = False
-
-    @property
-    def options(self) -> str:
-        return "sample --help"
-
-    def _verify_running_output(self, cmd_running_result: str) -> None:
-        self._should_contains_chars_in_result(cmd_running_result, "-h, --help")
-        self._should_contains_chars_in_result(cmd_running_result, "-p, --print-sample")
-        self._should_contains_chars_in_result(cmd_running_result, "-g, --generate-sample")
-        self._should_contains_chars_in_result(cmd_running_result, "-o FILE_PATH, --output FILE_PATH")
-
-
-class TestShowSampleConfiguration(SubCmdRestServerTestSuite):
-    Terminate_Command_Running_When_Sniff_IP_Info: bool = False
-
-    @property
-    def options(self) -> str:
-        return "sample -p"
-
-    def _verify_running_output(self, cmd_running_result: str) -> None:
-        for api_name, api_config in Mocked_APIs["apis"].items():
-            self._should_contains_chars_in_result(cmd_running_result, api_name)
-            self._should_contains_chars_in_result(cmd_running_result, api_config["url"])
-            if api_name != "base":
-                self._should_contains_chars_in_result(cmd_running_result, api_config["http"]["request"]["method"])
-                api_response_config = api_config["http"]["response"]
-                resp_value = api_response_config.get("value", None)
-                if resp_value:
-                    assert api_response_config["strategy"] in (
-                        ResponseStrategy.STRING.value,
-                        ResponseStrategy.FILE.value,
-                    )
-                    self._should_contains_chars_in_result(cmd_running_result, str(resp_value))
-                else:
-                    assert api_response_config["strategy"] == ResponseStrategy.OBJECT.value
-                    assert api_response_config["properties"]
-
-
-class TestGenerateSampleConfiguration(SubCmdRestServerTestSuite):
-    Terminate_Command_Running_When_Sniff_IP_Info: bool = False
-    _Default_Path: str = "sample-api.yaml"
-    _Under_Test_Path: Optional[str] = None
-
-    @property
-    def options(self) -> str:
-        return f"sample -g -o {self._Under_Test_Path}" if self._Under_Test_Path else "config -g"
-
-    @pytest.mark.parametrize("config_path", [None, "output-test-api.yaml"])
-    def test_command(self, config_path: str) -> None:
-        self._Under_Test_Path = config_path or self._Default_Path
-
-        # Check and clean file
-        if os.path.exists(self._Under_Test_Path):
-            os.remove(self._Under_Test_Path)
-
-        try:
-            super().test_command()
-        finally:
-            # clean file
-            if os.path.exists(self._Under_Test_Path):
-                os.remove(self._Under_Test_Path)
-
-    def _verify_running_output(self, cmd_running_result: str) -> None:
-        assert self._Under_Test_Path
-        assert os.path.exists(self._Under_Test_Path)
-        config_data = YAML().read(self._Under_Test_Path)
-        assert config_data == Sample_Config_Value
 
 
 class RunFakeServerTestSpec(SubCmdRestServerTestSuite, ABC):

--- a/test/system_test/run_cmd_sample.py
+++ b/test/system_test/run_cmd_sample.py
@@ -1,0 +1,88 @@
+import os
+from typing import Optional
+
+import pytest
+
+from fake_api_server._utils.file.operation import YAML
+from fake_api_server.model.api_config.apis import ResponseStrategy
+from fake_api_server.model.command.rest_server._sample import (
+    Mocked_APIs,
+    Sample_Config_Value,
+)
+
+from ._base import SubCmdRestServerTestSuite
+
+# isort: off
+
+# isort: on
+
+
+class TestSubCommandSample(SubCmdRestServerTestSuite):
+    Terminate_Command_Running_When_Sniff_IP_Info: bool = False
+
+    @property
+    def options(self) -> str:
+        return "sample --help"
+
+    def _verify_running_output(self, cmd_running_result: str) -> None:
+        self._should_contains_chars_in_result(cmd_running_result, "-h, --help")
+        self._should_contains_chars_in_result(cmd_running_result, "-p, --print-sample")
+        self._should_contains_chars_in_result(cmd_running_result, "-g, --generate-sample")
+        self._should_contains_chars_in_result(cmd_running_result, "-o FILE_PATH, --output FILE_PATH")
+
+
+class TestShowSampleConfiguration(SubCmdRestServerTestSuite):
+    Terminate_Command_Running_When_Sniff_IP_Info: bool = False
+
+    @property
+    def options(self) -> str:
+        return "sample -p"
+
+    def _verify_running_output(self, cmd_running_result: str) -> None:
+        for api_name, api_config in Mocked_APIs["apis"].items():
+            self._should_contains_chars_in_result(cmd_running_result, api_name)
+            self._should_contains_chars_in_result(cmd_running_result, api_config["url"])
+            if api_name != "base":
+                self._should_contains_chars_in_result(cmd_running_result, api_config["http"]["request"]["method"])
+                api_response_config = api_config["http"]["response"]
+                resp_value = api_response_config.get("value", None)
+                if resp_value:
+                    assert api_response_config["strategy"] in (
+                        ResponseStrategy.STRING.value,
+                        ResponseStrategy.FILE.value,
+                    )
+                    self._should_contains_chars_in_result(cmd_running_result, str(resp_value))
+                else:
+                    assert api_response_config["strategy"] == ResponseStrategy.OBJECT.value
+                    assert api_response_config["properties"]
+
+
+class TestGenerateSampleConfiguration(SubCmdRestServerTestSuite):
+    Terminate_Command_Running_When_Sniff_IP_Info: bool = False
+    _Default_Path: str = "sample-api.yaml"
+    _Under_Test_Path: Optional[str] = None
+
+    @property
+    def options(self) -> str:
+        return f"sample -g -o {self._Under_Test_Path}" if self._Under_Test_Path else "config -g"
+
+    @pytest.mark.parametrize("config_path", [None, "output-test-api.yaml"])
+    def test_command(self, config_path: str) -> None:
+        self._Under_Test_Path = config_path or self._Default_Path
+
+        # Check and clean file
+        if os.path.exists(self._Under_Test_Path):
+            os.remove(self._Under_Test_Path)
+
+        try:
+            super().test_command()
+        finally:
+            # clean file
+            if os.path.exists(self._Under_Test_Path):
+                os.remove(self._Under_Test_Path)
+
+    def _verify_running_output(self, cmd_running_result: str) -> None:
+        assert self._Under_Test_Path
+        assert os.path.exists(self._Under_Test_Path)
+        config_data = YAML().read(self._Under_Test_Path)
+        assert config_data == Sample_Config_Value

--- a/test/system_test/run_cmd_sample.py
+++ b/test/system_test/run_cmd_sample.py
@@ -10,9 +10,8 @@ from fake_api_server.model.command.rest_server._sample import (
     Sample_Config_Value,
 )
 
-from ._base import SubCmdRestServerTestSuite
-
 # isort: off
+from ._base import SubCmdRestServerTestSuite
 
 # isort: on
 

--- a/test/unit_test/command/process.py
+++ b/test/unit_test/command/process.py
@@ -28,6 +28,8 @@ from test._values import (
     _Log_Level,
     _Test_Config,
     _Workers_Amount,
+    _Daemon,
+    _Access_Log_File,
 )
 from test.unit_test.command._base.process import BaseCommandProcessorTestSpec
 
@@ -48,7 +50,13 @@ _Fake_Amt: int = 1
 
 
 def _given_command_option() -> CommandOptions:
-    return CommandOptions(bind=_Bind_Host_And_Port.value, workers=_Workers_Amount.value, log_level=_Log_Level.value)
+    return CommandOptions(
+        bind=_Bind_Host_And_Port.value,
+        workers=_Workers_Amount.value,
+        log_level=_Log_Level.value,
+        daemon=_Daemon.value,
+        access_log_file=_Access_Log_File.value,
+    )
 
 
 def _given_command(app_type: str) -> Command:
@@ -59,6 +67,8 @@ def _given_command(app_type: str) -> Command:
         bind=_Bind_Host_And_Port.value,
         workers=_Workers_Amount.value,
         log_level=_Log_Level.value,
+        daemon=_Daemon.value,
+        access_log_file=_Access_Log_File.value,
     )
     fake_cmd_option_obj = _given_command_option()
     return Command(entry_point="SGI tool command", app=fake_parser_arg.app_type, options=fake_cmd_option_obj)

--- a/test/unit_test/command/rest_server/run/component.py
+++ b/test/unit_test/command/rest_server/run/component.py
@@ -15,6 +15,8 @@ from test._values import (
     _Test_Auto_Type,
     _Test_Config,
     _Workers_Amount,
+    _Daemon,
+    _Access_Log_File,
 )
 
 # isort: on
@@ -46,6 +48,8 @@ class TestSubCmdRunComponent:
             bind=_Bind_Host_And_Port.value,
             workers=_Workers_Amount.value,
             log_level=_Log_Level.value,
+            daemon=_Daemon.value,
+            access_log_file=_Access_Log_File.value,
         )
 
         # Run target function to test

--- a/test/unit_test/command/rest_server/run/process.py
+++ b/test/unit_test/command/rest_server/run/process.py
@@ -15,6 +15,8 @@ from test._values import (
     _Test_Config,
     _Test_FastAPI_App_Type,
     _Workers_Amount,
+    _Daemon,
+    _Access_Log_File,
 )
 from test.unit_test.command._base.process import BaseCommandProcessorTestSpec
 
@@ -108,6 +110,8 @@ class TestSubCmdRun(BaseCommandProcessorTestSpec):
             bind=_Bind_Host_And_Port.value,
             workers=_Workers_Amount.value,
             log_level=_Log_Level.value,
+            daemon=_Daemon.value,
+            access_log_file=_Access_Log_File.value,
         )
 
     def _given_command(self, app_type: str) -> Command:
@@ -116,7 +120,13 @@ class TestSubCmdRun(BaseCommandProcessorTestSpec):
         return Command(entry_point="SGI tool command", app=mock_parser_arg.app_type, options=mock_cmd_option_obj)
 
     def _given_command_option(self) -> CommandOptions:
-        return CommandOptions(bind=_Bind_Host_And_Port.value, workers=_Workers_Amount.value, log_level=_Log_Level.value)
+        return CommandOptions(
+            bind=_Bind_Host_And_Port.value,
+            workers=_Workers_Amount.value,
+            log_level=_Log_Level.value,
+            daemon=_Daemon.value,
+            access_log_file=_Access_Log_File.value,
+        )
 
     def _given_cmd_args_namespace(self) -> Namespace:
         args_namespace = Namespace()
@@ -127,6 +137,8 @@ class TestSubCmdRun(BaseCommandProcessorTestSpec):
         args_namespace.bind = _Bind_Host_And_Port.value
         args_namespace.workers = _Workers_Amount.value
         args_namespace.log_level = _Log_Level.value
+        args_namespace.daemon = _Daemon.value
+        args_namespace.access_log_file = _Access_Log_File.value
         return args_namespace
 
     def _given_subcmd(self) -> Optional[SysArg]:

--- a/test/unit_test/model/command/rest_server/cmd_args.py
+++ b/test/unit_test/model/command/rest_server/cmd_args.py
@@ -58,6 +58,8 @@ from test._values import (
     _Test_Tag,
     _Test_URL,
     _Workers_Amount,
+    _Daemon,
+    _Access_Log_File,
 )
 
 # isort: on
@@ -100,6 +102,8 @@ class TestSubcmdRunArguments(CmdArgsDeserializeTestSuite):
             "bind": _Bind_Host_And_Port.value,
             "workers": _Workers_Amount.value,
             "log_level": _Log_Level.value,
+            "daemon": _Daemon.value,
+            "access_log_file": _Access_Log_File.value,
         }
         return Namespace(**namespace_args)
 
@@ -111,6 +115,8 @@ class TestSubcmdRunArguments(CmdArgsDeserializeTestSuite):
         assert argument.bind == _Bind_Host_And_Port.value
         assert argument.workers == _Workers_Amount.value
         assert argument.log_level == _Log_Level.value
+        assert argument.daemon == _Daemon.value
+        assert argument.access_log_file == _Access_Log_File.value
 
 
 class TestSubcmdAddArguments(CmdArgsDeserializeTestSuite):

--- a/test/unit_test/model/init.py
+++ b/test/unit_test/model/init.py
@@ -36,6 +36,8 @@ from test._values import (
     _Test_SubCommand_Pull,
     _Test_SubCommand_Run,
     _Workers_Amount,
+    _Daemon,
+    _Access_Log_File,
 )
 
 # isort: on
@@ -50,6 +52,8 @@ def test_deserialize_subcommand_run_args(mock_parser_arguments: Mock):
         "bind": _Bind_Host_And_Port.value,
         "workers": _Workers_Amount.value,
         "log_level": _Log_Level.value,
+        "daemon": _Daemon.value,
+        "access_log_file": _Access_Log_File.value,
     }
     namespace = Namespace(**namespace_args)
     deserialize_args.cli_rest_server.subcmd_run(namespace)

--- a/test/unit_test/server/rest/sgi/cmd.py
+++ b/test/unit_test/server/rest/sgi/cmd.py
@@ -22,6 +22,8 @@ from test._values import (
     _Log_Level,
     _Test_Config,
     _Workers_Amount,
+    _Daemon,
+    _Access_Log_File,
 )
 
 # isort: on
@@ -38,9 +40,15 @@ mock_parser_arg_obj = SubcmdRunArguments(
     bind=_Bind_Host_And_Port.value,
     workers=_Workers_Amount.value,
     log_level=_Log_Level.value,
+    daemon=_Daemon.value,
+    access_log_file=_Access_Log_File.value,
 )
 mock_cmd_option_obj = CommandOptions(
-    bind=_Bind_Host_And_Port.value, workers=_Workers_Amount.value, log_level=_Log_Level.value
+    bind=_Bind_Host_And_Port.value,
+    workers=_Workers_Amount.value,
+    log_level=_Log_Level.value,
+    daemon=_Daemon.value,
+    access_log_file=_Access_Log_File.value,
 )
 mock_cmd_obj = Command(entry_point="SGI tool command", app=app_path, options=mock_cmd_option_obj)
 
@@ -80,6 +88,8 @@ class BaseSGIServerTestSpec(metaclass=ABCMeta):
             bind=sgi_cmd.options.bind(address=mock_parser_arg_obj.bind),
             workers=sgi_cmd.options.workers(w=mock_parser_arg_obj.workers),
             log_level=sgi_cmd.options.log_level(level=mock_parser_arg_obj.log_level),
+            daemon=mock_parser_arg_obj.daemon,
+            access_log_file=mock_parser_arg_obj.access_log_file,
         )
         assert isinstance(command, Command)
 

--- a/test/unit_test/server/rest/sgi/model.py
+++ b/test/unit_test/server/rest/sgi/model.py
@@ -78,6 +78,10 @@ class TestCommand:
         expected_cmd = TestCommand.expected_cmd_line(command)
         assert command.line == expected_cmd
 
+    def test_daemonize_line(self, command: Command):
+        expected_cmd = TestCommand.expected_cmd_line(command)
+        assert command.line == expected_cmd
+
     @patch("subprocess.run")
     def test_run(self, mock_subprocess_run: Mock, command: Command):
         expected_cmd = TestCommand.expected_cmd_line(command)
@@ -87,4 +91,8 @@ class TestCommand:
     @classmethod
     def expected_cmd_line(cls, command: Command) -> str:
         host_and_port, workers, log_level = _get_cmd_options()
-        return " ".join([command.entry_point, host_and_port, workers, log_level, command.app_path])
+        entire_command_line = [command.entry_point, host_and_port, workers, log_level, command.app_path]
+        if command.options.daemon:
+            entire_command_line.insert(0, "nohup")
+            entire_command_line.append(f"&> {command.options.access_log_file} &")
+        return " ".join(entire_command_line)

--- a/test/unit_test/server/rest/sgi/model.py
+++ b/test/unit_test/server/rest/sgi/model.py
@@ -11,6 +11,8 @@ from test._values import (
     _Log_Level,
     _Test_Entry_Point,
     _Workers_Amount,
+    _Access_Log_File,
+    _Daemon,
 )
 
 # isort: on
@@ -31,7 +33,13 @@ class TestCommandOptions:
     @pytest.fixture(scope="function")
     def command_options(self) -> CommandOptions:
         host_and_port, workers, log_level = _get_cmd_options()
-        return CommandOptions(bind=host_and_port, workers=workers, log_level=log_level)
+        return CommandOptions(
+            bind=host_and_port,
+            workers=workers,
+            log_level=log_level,
+            daemon=_Daemon.value,
+            access_log_file=_Access_Log_File.value,
+        )
 
     def test_str(self, command_options: CommandOptions):
         options = str(command_options)
@@ -57,7 +65,13 @@ class TestCommand:
         return Command(
             entry_point=_Test_Entry_Point,
             app="application instance path",
-            options=CommandOptions(bind=host_and_port, workers=workers, log_level=log_level),
+            options=CommandOptions(
+                bind=host_and_port,
+                workers=workers,
+                log_level=log_level,
+                daemon=_Daemon.value,
+                access_log_file=_Access_Log_File.value,
+            ),
         )
 
     def test_line(self, command: Command):

--- a/test/unit_test/server/rest/sgi/model.py
+++ b/test/unit_test/server/rest/sgi/model.py
@@ -94,5 +94,5 @@ class TestCommand:
         entire_command_line = [command.entry_point, host_and_port, workers, log_level, command.app_path]
         if command.options.daemon:
             entire_command_line.insert(0, "nohup")
-            entire_command_line.append(f"> {command.options.access_log_file} &")
+            entire_command_line.append(f"> {command.options.access_log_file} 2>&1 &")
         return " ".join(entire_command_line)

--- a/test/unit_test/server/rest/sgi/model.py
+++ b/test/unit_test/server/rest/sgi/model.py
@@ -94,5 +94,5 @@ class TestCommand:
         entire_command_line = [command.entry_point, host_and_port, workers, log_level, command.app_path]
         if command.options.daemon:
             entire_command_line.insert(0, "nohup")
-            entire_command_line.append(f"&> {command.options.access_log_file} &")
+            entire_command_line.append(f"> {command.options.access_log_file} &")
         return " ".join(entire_command_line)


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

[//]: # (The summary what you did or your target.)
* ### Task summary:

    Support run the fake server in background by CLI.

[//]: # (The task ID in ClickUp [project: https://app.clickup.com/9018752317/v/f/90183126979/90182605225] which maps this change.)
* ### Task tickets:

    * Task ID: CU-86erhgv81.
    * Relative task IDs: N/A.

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    N/A.


[//]: # (What's the scope in project it would affect with your modify? For example, would it affect CI workflow? Or any feature usage? Please list all the items which may be affected.)
## _Effecting Scope_

* Adding new feature without any breaking change.


[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

* Add new command line options about running program in background without blocking thread or process.
* Refactor the system test to be more clear and readable.
* Additional:
    * Key change: [f16c026](https://github.com/Chisanan232/PyFake-API-Server/pull/469/commits/f16c026ebaf48bf361e1091e0ad350f073cc5b5a)
    * Reason: Incorrect usage of command line `nohup` and `&` will cause the output streaming still could be catch outside. Which would cause the test would catch the output value unexpectly.
    * refer: https://stackoverflow.com/questions/818255/what-does-21-mean
