### PR TITLE
[CU-86erprxap] Adjust the setting about the versioning info of documentation.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,7 +83,17 @@ plugins:
       javascript_dir: js
   # Documentation modification info - create & update time
   - git-revision-date-localized:
+      type: timeago
+#      custom_format: "%d. %B %Y"
+      timezone: Asia/Taipei
+#      locale: en
+      fallback_to_build_date: false
       enable_creation_date: true
+#      exclude:
+#          - index.md
+      enable_git_follow: true
+      enabled: true
+      strict: true
   # Documentation modification info - contributor
   - git-committers:
       repository: Chisanan232/PyFake-API-Server


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

[//]: # (The summary what you did or your target.)
* ### Task summary:

    Adjust the setting about the versioning info of documentation.

[//]: # (The task ID in ClickUp [project: https://app.clickup.com/9018752317/v/f/90183126979/90182605225] which maps this change.)
* ### Task tickets:

    * Task ID: CU-86erprxap.
    * Relative task IDs: N/A.

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    AS IS:
        <img width="766" alt="Screenshot 2025-03-03 at 12 54 48 PM" src="https://github.com/user-attachments/assets/a7151db3-5eb5-4f29-83d6-a22f76892c03" />
    TO BE:
        <img width="659" alt="Screenshot 2025-03-03 at 12 55 14 PM" src="https://github.com/user-attachments/assets/2d98c4a4-c4f2-4775-82a1-351b36246106" />


[//]: # (What's the scope in project it would affect with your modify? For example, would it affect CI workflow? Or any feature usage? Please list all the items which may be affected.)
## _Effecting Scope_

* Nothing breaking changes.


[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

* Adjust the versioning info setting at documentation to let it could display the created time and updated time to be readable and correct.
