### PR TITLE
[CU-86erhh4kh] Fix the workflow parameter naming issue to release new version `0.4.1`

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -37,5 +37,5 @@ jobs:
       release-type: ${{ needs.build_git-tag_and_create_github-release.outputs.python_release_version }}
       push-to-PyPI: official
     secrets:
-      pypi_user: ${{ secrets.PYPI_USERNAME }}
-      pypi_token: ${{ secrets.PYPI_PASSWORD }}
+      PyPI_user: ${{ secrets.PYPI_USERNAME }}
+      PyPI_token: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -7,6 +7,7 @@ on:
       - "master"
     paths:
 #     This deployment workflow would only be triggered by file change of module *__pkg_info__* because it has the package version info.
+      - ".github/workflows/cd.yaml"    # For test or emergency scenario only
       - "**/__pkg_info__.py"
 
 jobs:


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

[//]: # (The summary what you did or your target.)
* ### Task summary:

    Fix the workflow parameter naming issue to release new version `0.4.1`.

[//]: # (The task ID in ClickUp [project: https://app.clickup.com/9018752317/v/f/90183126979/90182605225] which maps this change.)
* ### Task tickets:

    * Task ID: CU-86erhh4kh.
    * Relative task IDs: N/A.
    * Relative PR: https://github.com/Chisanan232/PyFake-API-Server/pull/472

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    Error in deployment workflow: https://github.com/Chisanan232/PyFake-API-Server/actions/runs/13665306102


[//]: # (What's the scope in project it would affect with your modify? For example, would it affect CI workflow? Or any feature usage? Please list all the items which may be affected.)
## _Effecting Scope_

* Fix the deployment workflow error.
* Official release this project to trigger all deployment CD workflows.


[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

* Fix the deployment workflow bug.
* Add one more condition for emergency scenario to force to release.

