### PR TITLE
[CU-86eryru4a] Fix the bug about it doesn't set default value at command line options if the default value is empty string value

### DIFF
--- a/fake_api_server/command/_base/options.py
+++ b/fake_api_server/command/_base/options.py
@@ -151,7 +151,9 @@ class CommandOption:
             "dest": self.name,
             "help": self.help_description_content,
             "type": self.option_value_type,
-            "default": self.default_value,
+            "default": self.default_value if not self._is_constant_action else None,
+            "const": self.default_value if self._is_constant_action else None,
+            "nargs": "?" if self._is_constant_action else None,
             "action": self.action or "store",
         }
         cmd_option_args_clone = copy.copy(cmd_option_args)
@@ -170,6 +172,10 @@ class CommandOption:
 
     def copy(self) -> "CommandOption":
         return copy.copy(self)
+
+    @property
+    def _is_constant_action(self) -> bool:
+        return (self.action is not None) and ("const" in self.action)
 
     def _dispatch_parser(self, parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         if self.sub_cmd and self.sub_parser:

--- a/fake_api_server/command/_base/options.py
+++ b/fake_api_server/command/_base/options.py
@@ -158,7 +158,7 @@ class CommandOption:
         }
         cmd_option_args_clone = copy.copy(cmd_option_args)
         for arg_name, arg_val in cmd_option_args.items():
-            if not arg_val:
+            if arg_val is None:
                 cmd_option_args_clone.pop(arg_name)
         return cmd_option_args_clone
 

--- a/fake_api_server/command/rest_server/pull/options.py
+++ b/fake_api_server/command/rest_server/pull/options.py
@@ -54,6 +54,7 @@ class BaseURL(BaseSubCmdPullOption):
     cli_option: str = "--base-url"
     name: str = "base_url"
     help_description: str = "The base URL which must be the part of path all the APIs begin with."
+    default_value: str = ""
 
 
 class BaseFilePath(BaseSubCmdPullOption):

--- a/fake_api_server/command/rest_server/pull/options.py
+++ b/fake_api_server/command/rest_server/pull/options.py
@@ -65,6 +65,7 @@ class BaseFilePath(BaseSubCmdPullOption):
         "words, it would automatically add the base path in front of all the other file "
         "paths in configuration."
     )
+    default_value: str = "./"
 
 
 class IncludeTemplateConfig(BaseSubCmdPullOption):


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

[//]: # (The summary what you did or your target.)
* ### Task summary:

    Fix the bug about it doesn't set default value at command line options if the default value is empty string value.

[//]: # (The task ID in ClickUp [project: https://app.clickup.com/9018752317/v/f/90183126979/90182605225] which maps this change.)
* ### Task tickets:

    * Task ID: CU-86eryru4a.
    * Relative task IDs: N/A.

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    N/A.


[//]: # (What's the scope in project it would affect with your modify? For example, would it affect CI workflow? Or any feature usage? Please list all the items which may be affected.)
## _Effecting Scope_

* Fix the program bug without any breaking change.


[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

* Add new properties at command line adding function.
* Adjust the filtering logic for `None` value only. It cannot filter empty string value.
