### PR TITLE
[CU-86erz3cda] Fix bug about setting incorrect customized format value by subcommand line `pull`

### DIFF
--- a/fake_api_server/model/rest_api_doc_config/_model_adapter.py
+++ b/fake_api_server/model/rest_api_doc_config/_model_adapter.py
@@ -37,7 +37,7 @@ class FormatAdapter(BaseFormatModelAdapter):
         def _configure_customize(customize: str, value_format: ValueFormat) -> Tuple[str, List[Variable]]:
             cust = customize
             var = [Variable(name=cust, value_format=value_format)]
-            return cust, var
+            return f"<{cust}>", var
 
         if self.enum:
             return PyFake_Format(

--- a/test/data/divide_test_pull/divide_api+has_tag/expect_config/foo-boo/get_foo-boo_export-api.yaml
+++ b/test/data/divide_test_pull/divide_api+has_tag/expect_config/foo-boo/get_foo-boo_export-api.yaml
@@ -28,7 +28,7 @@ http:
         type: str
         format:
           strategy: customize
-          customize: "datetime_value"
+          customize: "<datetime_value>"
           variables:
             - name: datetime_value
               value_format: date-time
@@ -60,7 +60,7 @@ http:
         type: str
         format:
           strategy: customize
-          customize: "uri_value"
+          customize: "<uri_value>"
           variables:
             - name: uri_value
               value_format: uri
@@ -69,7 +69,7 @@ http:
         type: str
         format:
           strategy: customize
-          customize: "url_value"
+          customize: "<url_value>"
           variables:
             - name: url_value
               value_format: url

--- a/test/data/divide_test_pull/divide_api+has_tag/expect_config/foo/get_foo-api.yaml
+++ b/test/data/divide_test_pull/divide_api+has_tag/expect_config/foo/get_foo-api.yaml
@@ -9,7 +9,7 @@ http:
         type: str
         format:
           strategy: customize
-          customize: "datetime_value"
+          customize: "<datetime_value>"
           variables:
             - name: datetime_value
               value_format: date-time

--- a/test/data/divide_test_pull/divide_api+has_tag_include_template/expect_config/foo-boo/get_foo-boo_export-api.yaml
+++ b/test/data/divide_test_pull/divide_api+has_tag_include_template/expect_config/foo-boo/get_foo-boo_export-api.yaml
@@ -28,7 +28,7 @@ http:
         type: str
         format:
           strategy: customize
-          customize: datetime_value
+          customize: <datetime_value>
           variables:
             - name: datetime_value
               value_format: "date-time"
@@ -60,7 +60,7 @@ http:
         type: str
         format:
           strategy: customize
-          customize: uri_value
+          customize: <uri_value>
           variables:
             - name: uri_value
               value_format: "uri"
@@ -69,7 +69,7 @@ http:
         type: str
         format:
           strategy: customize
-          customize: url_value
+          customize: <url_value>
           variables:
             - name: url_value
               value_format: "url"

--- a/test/data/divide_test_pull/divide_api+has_tag_include_template/expect_config/foo/get_foo-api.yaml
+++ b/test/data/divide_test_pull/divide_api+has_tag_include_template/expect_config/foo/get_foo-api.yaml
@@ -9,7 +9,7 @@ http:
         type: str
         format:
           strategy: customize
-          customize: datetime_value
+          customize: <datetime_value>
           variables:
             - name: datetime_value
               value_format: "date-time"

--- a/test/data/divide_test_pull/divide_api_http+has_tag_include_template/expect_config/foo-boo/get_foo-boo_export-http.yaml
+++ b/test/data/divide_test_pull/divide_api_http+has_tag_include_template/expect_config/foo-boo/get_foo-boo_export-http.yaml
@@ -25,7 +25,7 @@ request:
       type: str
       format:
         strategy: customize
-        customize: datetime_value
+        customize: <datetime_value>
         variables:
           - name: datetime_value
             value_format: "date-time"
@@ -57,7 +57,7 @@ response:
       type: str
       format:
         strategy: customize
-        customize: uri_value
+        customize: <uri_value>
         variables:
           - name: uri_value
             value_format: "uri"
@@ -66,7 +66,7 @@ response:
       type: str
       format:
         strategy: customize
-        customize: url_value
+        customize: <url_value>
         variables:
           - name: url_value
             value_format: "url"

--- a/test/data/divide_test_pull/divide_api_http+has_tag_include_template/expect_config/foo/get_foo-http.yaml
+++ b/test/data/divide_test_pull/divide_api_http+has_tag_include_template/expect_config/foo/get_foo-http.yaml
@@ -6,7 +6,7 @@ request:
       type: str
       format:
         strategy: customize
-        customize: datetime_value
+        customize: <datetime_value>
         variables:
           - name: datetime_value
             value_format: "date-time"

--- a/test/data/divide_test_pull/divide_api_http_response+has_tag_include_template/expect_config/foo-boo/get_foo-boo_export-http.yaml
+++ b/test/data/divide_test_pull/divide_api_http_response+has_tag_include_template/expect_config/foo-boo/get_foo-boo_export-http.yaml
@@ -25,7 +25,7 @@ request:
       type: str
       format:
         strategy: customize
-        customize: datetime_value
+        customize: <datetime_value>
         variables:
           - name: datetime_value
             value_format: "date-time"

--- a/test/data/divide_test_pull/divide_api_http_response+has_tag_include_template/expect_config/foo-boo/get_foo-boo_export-response.yaml
+++ b/test/data/divide_test_pull/divide_api_http_response+has_tag_include_template/expect_config/foo-boo/get_foo-boo_export-response.yaml
@@ -25,7 +25,7 @@ properties:
     type: str
     format:
       strategy: customize
-      customize: uri_value
+      customize: <uri_value>
       variables:
         - name: uri_value
           value_format: "uri"
@@ -34,7 +34,7 @@ properties:
     type: str
     format:
       strategy: customize
-      customize: url_value
+      customize: <url_value>
       variables:
         - name: url_value
           value_format: "url"

--- a/test/data/divide_test_pull/divide_api_http_response+has_tag_include_template/expect_config/foo/get_foo-http.yaml
+++ b/test/data/divide_test_pull/divide_api_http_response+has_tag_include_template/expect_config/foo/get_foo-http.yaml
@@ -6,7 +6,7 @@ request:
       type: str
       format:
         strategy: customize
-        customize: datetime_value
+        customize: <datetime_value>
         variables:
           - name: datetime_value
             value_format: "date-time"

--- a/test/data/divide_test_pull/divide_api_http_response_with_nested_data+has_tag_include_template/expect_config/foo-boo/get_foo-boo_export-http.yaml
+++ b/test/data/divide_test_pull/divide_api_http_response_with_nested_data+has_tag_include_template/expect_config/foo-boo/get_foo-boo_export-http.yaml
@@ -25,7 +25,7 @@ request:
       type: str
       format:
         strategy: customize
-        customize: datetime_value
+        customize: <datetime_value>
         variables:
           - name: datetime_value
             value_format: "date-time"

--- a/test/data/divide_test_pull/divide_api_http_response_with_nested_data+has_tag_include_template/expect_config/foo-boo/get_foo-boo_export-response.yaml
+++ b/test/data/divide_test_pull/divide_api_http_response_with_nested_data+has_tag_include_template/expect_config/foo-boo/get_foo-boo_export-response.yaml
@@ -25,7 +25,7 @@ properties:
     type: str
     format:
       strategy: customize
-      customize: uri_value
+      customize: <uri_value>
       variables:
         - name: uri_value
           value_format: "uri"
@@ -34,7 +34,7 @@ properties:
     type: str
     format:
       strategy: customize
-      customize: url_value
+      customize: <url_value>
       variables:
         - name: url_value
           value_format: "url"

--- a/test/data/divide_test_pull/divide_api_http_response_with_nested_data+has_tag_include_template/expect_config/foo/get_foo-http.yaml
+++ b/test/data/divide_test_pull/divide_api_http_response_with_nested_data+has_tag_include_template/expect_config/foo/get_foo-http.yaml
@@ -6,7 +6,7 @@ request:
       type: str
       format:
         strategy: customize
-        customize: datetime_value
+        customize: <datetime_value>
         variables:
           - name: datetime_value
             value_format: "date-time"

--- a/test/data/divide_test_pull/divide_api_with_dict_as_ref+has_tag/expect_config/foo-boo/get_foo-boo-api.yaml
+++ b/test/data/divide_test_pull/divide_api_with_dict_as_ref+has_tag/expect_config/foo-boo/get_foo-boo-api.yaml
@@ -9,7 +9,7 @@ http:
         type: str
         format:
           strategy: customize
-          customize: datetime_value
+          customize: <datetime_value>
           variables:
             - name: datetime_value
               value_format: "date-time"

--- a/test/data/divide_test_pull/divide_api_with_dict_as_ref+has_tag/expect_config/foo-boo/get_foo-boo_export-api.yaml
+++ b/test/data/divide_test_pull/divide_api_with_dict_as_ref+has_tag/expect_config/foo-boo/get_foo-boo_export-api.yaml
@@ -28,7 +28,7 @@ http:
         type: str
         format:
           strategy: customize
-          customize: datetime_value
+          customize: <datetime_value>
           variables:
             - name: datetime_value
               value_format: "date-time"
@@ -60,7 +60,7 @@ http:
         type: str
         format:
           strategy: customize
-          customize: uri_value
+          customize: <uri_value>
           variables:
             - name: uri_value
               value_format: "uri"
@@ -69,7 +69,7 @@ http:
         type: str
         format:
           strategy: customize
-          customize: url_value
+          customize: <url_value>
           variables:
             - name: url_value
               value_format: "url"

--- a/test/data/divide_test_pull/divide_api_with_dict_as_ref+has_tag/expect_config/foo/get_foo-api.yaml
+++ b/test/data/divide_test_pull/divide_api_with_dict_as_ref+has_tag/expect_config/foo/get_foo-api.yaml
@@ -9,7 +9,7 @@ http:
         type: str
         format:
           strategy: customize
-          customize: datetime_value
+          customize: <datetime_value>
           variables:
             - name: datetime_value
               value_format: "date-time"

--- a/test/data/divide_test_pull/divide_api_with_dict_as_ref+has_tag_include_template/expect_config/foo-boo/get_foo-boo-api.yaml
+++ b/test/data/divide_test_pull/divide_api_with_dict_as_ref+has_tag_include_template/expect_config/foo-boo/get_foo-boo-api.yaml
@@ -9,7 +9,7 @@ http:
         type: str
         format:
           strategy: customize
-          customize: datetime_value
+          customize: <datetime_value>
           variables:
             - name: datetime_value
               value_format: "date-time"

--- a/test/data/divide_test_pull/divide_api_with_dict_as_ref+has_tag_include_template/expect_config/foo-boo/get_foo-boo_export-api.yaml
+++ b/test/data/divide_test_pull/divide_api_with_dict_as_ref+has_tag_include_template/expect_config/foo-boo/get_foo-boo_export-api.yaml
@@ -28,7 +28,7 @@ http:
         type: str
         format:
           strategy: customize
-          customize: datetime_value
+          customize: <datetime_value>
           variables:
             - name: datetime_value
               value_format: "date-time"
@@ -60,7 +60,7 @@ http:
         type: str
         format:
           strategy: customize
-          customize: uri_value
+          customize: <uri_value>
           variables:
             - name: uri_value
               value_format: "uri"
@@ -69,7 +69,7 @@ http:
         type: str
         format:
           strategy: customize
-          customize: url_value
+          customize: <url_value>
           variables:
             - name: url_value
               value_format: "url"

--- a/test/data/divide_test_pull/divide_api_with_dict_as_ref+has_tag_include_template/expect_config/foo/get_foo-api.yaml
+++ b/test/data/divide_test_pull/divide_api_with_dict_as_ref+has_tag_include_template/expect_config/foo/get_foo-api.yaml
@@ -9,7 +9,7 @@ http:
         type: str
         format:
           strategy: customize
-          customize: datetime_value
+          customize: <datetime_value>
           variables:
             - name: datetime_value
               value_format: "date-time"

--- a/test/data/divide_test_pull/divide_api_with_nested_data+has_tag/expect_config/foo-boo/get_foo-boo_export-api.yaml
+++ b/test/data/divide_test_pull/divide_api_with_nested_data+has_tag/expect_config/foo-boo/get_foo-boo_export-api.yaml
@@ -28,7 +28,7 @@ http:
         type: str
         format:
           strategy: customize
-          customize: datetime_value
+          customize: <datetime_value>
           variables:
             - name: datetime_value
               value_format: "date-time"
@@ -60,7 +60,7 @@ http:
         type: str
         format:
           strategy: customize
-          customize: uri_value
+          customize: <uri_value>
           variables:
             - name: uri_value
               value_format: "uri"
@@ -69,7 +69,7 @@ http:
         type: str
         format:
           strategy: customize
-          customize: url_value
+          customize: <url_value>
           variables:
             - name: url_value
               value_format: "url"

--- a/test/data/divide_test_pull/divide_api_with_nested_data+has_tag/expect_config/foo/get_foo-api.yaml
+++ b/test/data/divide_test_pull/divide_api_with_nested_data+has_tag/expect_config/foo/get_foo-api.yaml
@@ -9,7 +9,7 @@ http:
         type: str
         format:
           strategy: customize
-          customize: datetime_value
+          customize: <datetime_value>
           variables:
             - name: datetime_value
               value_format: "date-time"
@@ -64,7 +64,7 @@ http:
                     type: str
                     format:
                       strategy: customize
-                      customize: url_value
+                      customize: <url_value>
                       variables:
                         - name: url_value
                           value_format: "url"
@@ -80,7 +80,7 @@ http:
                     type: str
                     format:
                       strategy: customize
-                      customize: url_value
+                      customize: <url_value>
                       variables:
                         - name: url_value
                           value_format: "url"
@@ -96,7 +96,7 @@ http:
                     type: str
                     format:
                       strategy: customize
-                      customize: url_value
+                      customize: <url_value>
                       variables:
                         - name: url_value
                           value_format: "url"

--- a/test/data/divide_test_pull/divide_http+has_tag_include_template/expect_config/foo-boo/get_foo-boo_export-http.yaml
+++ b/test/data/divide_test_pull/divide_http+has_tag_include_template/expect_config/foo-boo/get_foo-boo_export-http.yaml
@@ -25,7 +25,7 @@ request:
       type: str
       format:
         strategy: customize
-        customize: datetime_value
+        customize: <datetime_value>
         variables:
           - name: datetime_value
             value_format: "date-time"
@@ -57,7 +57,7 @@ response:
       type: str
       format:
         strategy: customize
-        customize: uri_value
+        customize: <uri_value>
         variables:
           - name: uri_value
             value_format: "uri"
@@ -66,7 +66,7 @@ response:
       type: str
       format:
         strategy: customize
-        customize: url_value
+        customize: <url_value>
         variables:
           - name: url_value
             value_format: "url"

--- a/test/data/divide_test_pull/divide_http+has_tag_include_template/expect_config/foo/get_foo-http.yaml
+++ b/test/data/divide_test_pull/divide_http+has_tag_include_template/expect_config/foo/get_foo-http.yaml
@@ -6,7 +6,7 @@ request:
       type: str
       format:
         strategy: customize
-        customize: datetime_value
+        customize: <datetime_value>
         variables:
           - name: datetime_value
             value_format: "date-time"

--- a/test/data/divide_test_pull/divide_request+has_tag_include_template/expect_config/api.yaml
+++ b/test/data/divide_test_pull/divide_request+has_tag_include_template/expect_config/api.yaml
@@ -112,7 +112,7 @@ mocked_apis:
               type: str
               format:
                 strategy: customize
-                customize: uri_value
+                customize: <uri_value>
                 variables:
                   - name: uri_value
                     value_format: "uri"
@@ -121,7 +121,7 @@ mocked_apis:
               type: str
               format:
                 strategy: customize
-                customize: url_value
+                customize: <url_value>
                 variables:
                   - name: url_value
                     value_format: "url"

--- a/test/data/divide_test_pull/divide_request+has_tag_include_template/expect_config/foo-boo/get_foo-boo_export-request.yaml
+++ b/test/data/divide_test_pull/divide_request+has_tag_include_template/expect_config/foo-boo/get_foo-boo_export-request.yaml
@@ -24,7 +24,7 @@ parameters:
     type: str
     format:
       strategy: customize
-      customize: datetime_value
+      customize: <datetime_value>
       variables:
         - name: datetime_value
           value_format: "date-time"

--- a/test/data/divide_test_pull/divide_request+has_tag_include_template/expect_config/foo/get_foo-request.yaml
+++ b/test/data/divide_test_pull/divide_request+has_tag_include_template/expect_config/foo/get_foo-request.yaml
@@ -5,7 +5,7 @@ parameters:
     type: str
     format:
       strategy: customize
-      customize: datetime_value
+      customize: <datetime_value>
       variables:
         - name: datetime_value
           value_format: "date-time"

--- a/test/data/pull_test/config/from_v2_openapi/has-base-info_and_tags.yaml
+++ b/test/data/pull_test/config/from_v2_openapi/has-base-info_and_tags.yaml
@@ -15,7 +15,7 @@ mocked_apis:
               type: str
               format:
                 strategy: customize
-                customize: "datetime_value"
+                customize: "<datetime_value>"
                 variables:
                   - name: datetime_value
                     value_format: date-time
@@ -142,7 +142,7 @@ mocked_apis:
               type: str
               format:
                 strategy: customize
-                customize: "datetime_value"
+                customize: "<datetime_value>"
                 variables:
                   - name: datetime_value
                     value_format: date-time
@@ -174,7 +174,7 @@ mocked_apis:
               type: str
               format:
                 strategy: customize
-                customize: uri_value
+                customize: <uri_value>
                 variables:
                   - name: uri_value
                     value_format: "uri"
@@ -183,7 +183,7 @@ mocked_apis:
               type: str
               format:
                 strategy: customize
-                customize: url_value
+                customize: <url_value>
                 variables:
                   - name: url_value
                     value_format: "url"

--- a/test/unit_test/model/rest_api_doc_config/_base_config.py
+++ b/test/unit_test/model/rest_api_doc_config/_base_config.py
@@ -170,7 +170,7 @@ class BaseAPIDocConfigTestSuite(metaclass=ABCMeta):
                     "type": "str",
                     "format": {
                         "strategy": "customize",
-                        "customize": "uri_value",
+                        "customize": "<uri_value>",
                         "variables": [{"name": "uri_value", "value_format": "uri"}],
                     },
                 },
@@ -286,7 +286,7 @@ class BaseAPIDocConfigTestSuite(metaclass=ABCMeta):
                                     "type": "str",
                                     "format": {
                                         "strategy": "customize",
-                                        "customize": "uri_value",
+                                        "customize": "<uri_value>",
                                         "variables": [{"name": "uri_value", "value_format": "uri"}],
                                     },
                                 },
@@ -358,7 +358,7 @@ class BaseAPIDocConfigTestSuite(metaclass=ABCMeta):
                                 "type": "str",
                                 "format": {
                                     "strategy": "customize",
-                                    "customize": "uri_value",
+                                    "customize": "<uri_value>",
                                     "variables": [{"name": "uri_value", "value_format": "uri"}],
                                 },
                             },

--- a/test/unit_test/model/rest_api_doc_config/_base_config.py
+++ b/test/unit_test/model/rest_api_doc_config/_base_config.py
@@ -844,7 +844,7 @@ class _BasePropertyDetailAdapterTestSuite(metaclass=ABCMeta):
                     value_type="str",
                     format=Format(
                         strategy=FormatStrategy.CUSTOMIZE,
-                        customize="datetime_value",
+                        customize="<datetime_value>",
                         variables=[Variable(name="datetime_value", value_format=ValueFormat.DateTime)],
                     ),
                     items=None,
@@ -876,7 +876,7 @@ class _BasePropertyDetailAdapterTestSuite(metaclass=ABCMeta):
                             value_type="str",
                             format=Format(
                                 strategy=FormatStrategy.CUSTOMIZE,
-                                customize="datetime_value",
+                                customize="<datetime_value>",
                                 variables=[Variable(name="datetime_value", value_format=ValueFormat.DateTime)],
                             ),
                             items=None,
@@ -930,7 +930,7 @@ class _BasePropertyDetailAdapterTestSuite(metaclass=ABCMeta):
                             value_type="str",
                             format=Format(
                                 strategy=FormatStrategy.CUSTOMIZE,
-                                customize="datetime_value",
+                                customize="<datetime_value>",
                                 variables=[Variable(name="datetime_value", value_format=ValueFormat.DateTime)],
                             ),
                             items=None,

--- a/test/unit_test/model/rest_api_doc_config/inner_model_adapter.py
+++ b/test/unit_test/model/rest_api_doc_config/inner_model_adapter.py
@@ -106,42 +106,42 @@ class TestFormatAdapter:
 
             elif pyfake_config.strategy is FormatStrategy.CUSTOMIZE:
                 if formatter is ApiDocValueFormat.Date:
-                    assert pyfake_config.customize == "date_value"
+                    assert pyfake_config.customize == "<date_value>"
                     assert pyfake_config.variables
                     assert pyfake_config.variables[0].name == "date_value"
                     assert pyfake_config.variables[0].value_format == ValueFormat.Date
                 elif formatter is ApiDocValueFormat.DateTime:
-                    assert pyfake_config.customize == "datetime_value"
+                    assert pyfake_config.customize == "<datetime_value>"
                     assert pyfake_config.variables
                     assert pyfake_config.variables[0].name == "datetime_value"
                     assert pyfake_config.variables[0].value_format == ValueFormat.DateTime
                 elif formatter is ApiDocValueFormat.EMail:
-                    assert pyfake_config.customize == "email_value"
+                    assert pyfake_config.customize == "<email_value>"
                     assert pyfake_config.variables
                     assert pyfake_config.variables[0].name == "email_value"
                     assert pyfake_config.variables[0].value_format == ValueFormat.EMail
                 elif formatter is ApiDocValueFormat.UUID:
-                    assert pyfake_config.customize == "uuid_value"
+                    assert pyfake_config.customize == "<uuid_value>"
                     assert pyfake_config.variables
                     assert pyfake_config.variables[0].name == "uuid_value"
                     assert pyfake_config.variables[0].value_format == ValueFormat.UUID
                 elif formatter is ApiDocValueFormat.URI:
-                    assert pyfake_config.customize == "uri_value"
+                    assert pyfake_config.customize == "<uri_value>"
                     assert pyfake_config.variables
                     assert pyfake_config.variables[0].name == "uri_value"
                     assert pyfake_config.variables[0].value_format == ValueFormat.URI
                 elif formatter is ApiDocValueFormat.URL:
-                    assert pyfake_config.customize == "url_value"
+                    assert pyfake_config.customize == "<url_value>"
                     assert pyfake_config.variables
                     assert pyfake_config.variables[0].name == "url_value"
                     assert pyfake_config.variables[0].value_format == ValueFormat.URL
                 elif formatter is ApiDocValueFormat.IPv4:
-                    assert pyfake_config.customize == "ipv4_value"
+                    assert pyfake_config.customize == "<ipv4_value>"
                     assert pyfake_config.variables
                     assert pyfake_config.variables[0].name == "ipv4_value"
                     assert pyfake_config.variables[0].value_format == ValueFormat.IPv4
                 elif formatter is ApiDocValueFormat.IPv6:
-                    assert pyfake_config.customize == "ipv6_value"
+                    assert pyfake_config.customize == "<ipv6_value>"
                     assert pyfake_config.variables
                     assert pyfake_config.variables[0].name == "ipv6_value"
                     assert pyfake_config.variables[0].value_format == ValueFormat.IPv6


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

[//]: # (The summary what you did or your target.)
* ### Task summary:

    Fix bug about setting incorrect customized format value by subcommand line `pull`.

[//]: # (The task ID in ClickUp [project: https://app.clickup.com/9018752317/v/f/90183126979/90182605225] which maps this change.)
* ### Task tickets:

    * Task ID: CU-86erz3cda.
    * Relative task IDs: N/A.

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    N/A.


[//]: # (What's the scope in project it would affect with your modify? For example, would it affect CI workflow? Or any feature usage? Please list all the items which may be affected.)
## _Effecting Scope_

* Fix bug without any breaking changes.


[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

* Fix the bug about it should set the customized value as variable format value which be defined by **_Fake-API-Server_** when converting OpenAPI documentation models into Fake-API-Server models.
* Fix the incorrect test data criterias.
