### PR TITLE
[CU-86erzzr0c] Fix the bug about the command line info cannot be parsed in some  runtime environment with specific format.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -134,4 +134,4 @@ jobs:
       build-type: poetry
       python_package_name: fake-api-server
       test_shell_in_python: from fake_api_server.runner import run
-      test_shell: fake --help
+      test_shell: fake rest-server run --help

--- a/fake_api_server/model/subcmd_common.py
+++ b/fake_api_server/model/subcmd_common.py
@@ -16,7 +16,9 @@ class SysArg:
         if not args:
             return SysArg(subcmd=SubCommandLine.Base)
 
-        no_pyfile_subcmds = list(filter(lambda a: not re.search(r".{1,1024}.py", a), args))
+        no_pyfile_subcmds = list(
+            filter(lambda a: not re.search(r".{1,1024}.py", a) and not re.search(r".{0,1024}fake", a), args)
+        )
         subcmds: List[str] = []
         for subcmd_or_options in no_pyfile_subcmds:
             search_subcmd = re.search(r"-.{1,256}", subcmd_or_options)

--- a/fake_api_server/model/subcmd_common.py
+++ b/fake_api_server/model/subcmd_common.py
@@ -16,11 +16,11 @@ class SysArg:
         if not args:
             return SysArg(subcmd=SubCommandLine.Base)
 
-        no_pyfile_subcmds = list(
+        no_pyfile_or_program_subcmds = list(
             filter(lambda a: not re.search(r".{1,1024}.py", a) and not re.search(r".{0,1024}fake", a), args)
         )
         subcmds: List[str] = []
-        for subcmd_or_options in no_pyfile_subcmds:
+        for subcmd_or_options in no_pyfile_or_program_subcmds:
             search_subcmd = re.search(r"-.{1,256}", subcmd_or_options)
             if search_subcmd and len(search_subcmd.group(0)) == len(subcmd_or_options):
                 break

--- a/test/unit_test/model/subcmd_common.py
+++ b/test/unit_test/model/subcmd_common.py
@@ -5,6 +5,10 @@ import pytest
 from fake_api_server.command.subcommand import SubCommandLine
 from fake_api_server.model.subcmd_common import SysArg
 
+USE_PYTHON_FILE_RUN_CMD: str = "pyfake.py"
+USE_RELATIVE_PYTHON_FILE_PATH_RUN_CMD: str = "./pyfake.py"
+USE_MORE_RELATIVE_PYTHON_FILE_PATH_RUN_CMD: str = "./test/pyfake.py"
+
 
 class TestSysArg:
 
@@ -12,27 +16,27 @@ class TestSysArg:
         ("sys_args_value", "expect_data_model"),
         [
             # only one sub-command
-            (["pyfake.py", "--help"], SysArg(pre_subcmd=None, subcmd=SubCommandLine.Base)),
-            (["pyfake.py", "-h"], SysArg(pre_subcmd=None, subcmd=SubCommandLine.Base)),
+            ([USE_PYTHON_FILE_RUN_CMD, "--help"], SysArg(pre_subcmd=None, subcmd=SubCommandLine.Base)),
+            ([USE_PYTHON_FILE_RUN_CMD, "-h"], SysArg(pre_subcmd=None, subcmd=SubCommandLine.Base)),
             (
-                ["pyfake.py", "run"],
+                [USE_PYTHON_FILE_RUN_CMD, "run"],
                 SysArg(pre_subcmd=SysArg(pre_subcmd=None, subcmd=SubCommandLine.Base), subcmd=SubCommandLine.Run),
             ),
             (
-                ["./test/pyfake.py", "run", "-h"],
+                [USE_MORE_RELATIVE_PYTHON_FILE_PATH_RUN_CMD, "run", "-h"],
                 SysArg(pre_subcmd=SysArg(pre_subcmd=None, subcmd=SubCommandLine.Base), subcmd=SubCommandLine.Run),
             ),
             (
-                ["./pyfake.py", "run", "-c", "./sample-api.yaml"],
+                [USE_RELATIVE_PYTHON_FILE_PATH_RUN_CMD, "run", "-c", "./sample-api.yaml"],
                 SysArg(pre_subcmd=SysArg(pre_subcmd=None, subcmd=SubCommandLine.Base), subcmd=SubCommandLine.Run),
             ),
             (
-                ["./pyfake.py", "run", "--app-type", "fastapi"],
+                [USE_RELATIVE_PYTHON_FILE_PATH_RUN_CMD, "run", "--app-type", "fastapi"],
                 SysArg(pre_subcmd=SysArg(pre_subcmd=None, subcmd=SubCommandLine.Base), subcmd=SubCommandLine.Run),
             ),
             # nested sub-command which includes 2 or more sub-commands
             (
-                ["./test/pyfake.py", "rest-server", "run", "-h"],
+                [USE_MORE_RELATIVE_PYTHON_FILE_PATH_RUN_CMD, "rest-server", "run", "-h"],
                 SysArg(
                     pre_subcmd=SysArg(
                         pre_subcmd=SysArg(pre_subcmd=None, subcmd=SubCommandLine.Base), subcmd=SubCommandLine.RestServer
@@ -41,7 +45,7 @@ class TestSysArg:
                 ),
             ),
             (
-                ["./test/pyfake.py", "rest-server", "run", "-c", "./sample-api.yaml"],
+                [USE_MORE_RELATIVE_PYTHON_FILE_PATH_RUN_CMD, "rest-server", "run", "-c", "./sample-api.yaml"],
                 SysArg(
                     pre_subcmd=SysArg(
                         pre_subcmd=SysArg(pre_subcmd=None, subcmd=SubCommandLine.Base), subcmd=SubCommandLine.RestServer
@@ -50,7 +54,7 @@ class TestSysArg:
                 ),
             ),
             (
-                ["./test/pyfake.py", "rest-server", "run", "--app-type", "fastapi"],
+                [USE_MORE_RELATIVE_PYTHON_FILE_PATH_RUN_CMD, "rest-server", "run", "--app-type", "fastapi"],
                 SysArg(
                     pre_subcmd=SysArg(
                         pre_subcmd=SysArg(pre_subcmd=None, subcmd=SubCommandLine.Base), subcmd=SubCommandLine.RestServer

--- a/test/unit_test/model/subcmd_common.py
+++ b/test/unit_test/model/subcmd_common.py
@@ -8,6 +8,7 @@ from fake_api_server.model.subcmd_common import SysArg
 USE_PYTHON_FILE_RUN_CMD: str = "pyfake.py"
 USE_RELATIVE_PYTHON_FILE_PATH_RUN_CMD: str = "./pyfake.py"
 USE_MORE_RELATIVE_PYTHON_FILE_PATH_RUN_CMD: str = "./test/pyfake.py"
+USE_POETRY_RUN_CMD: str = "/Users/bryant/Library/Caches/pypoetry/virtualenvs/fake-api-server-LE7TJquz-py3.12/bin/fake"
 
 
 class TestSysArg:
@@ -60,6 +61,33 @@ class TestSysArg:
                         pre_subcmd=SysArg(pre_subcmd=None, subcmd=SubCommandLine.Base), subcmd=SubCommandLine.RestServer
                     ),
                     subcmd=SubCommandLine.Run,
+                ),
+            ),
+            # run sub-command by Poetry environment
+            ([USE_POETRY_RUN_CMD, "--help"], SysArg(pre_subcmd=None, subcmd=SubCommandLine.Base)),
+            (
+                [USE_POETRY_RUN_CMD, "rest-server", "-h"],
+                SysArg(
+                    pre_subcmd=SysArg(pre_subcmd=None, subcmd=SubCommandLine.Base),
+                    subcmd=SubCommandLine.RestServer,
+                ),
+            ),
+            (
+                [USE_POETRY_RUN_CMD, "rest-server", "run", "-h"],
+                SysArg(
+                    pre_subcmd=SysArg(
+                        pre_subcmd=SysArg(pre_subcmd=None, subcmd=SubCommandLine.Base), subcmd=SubCommandLine.RestServer
+                    ),
+                    subcmd=SubCommandLine.Run,
+                ),
+            ),
+            (
+                [USE_POETRY_RUN_CMD, "rest-server", "pull", "-h"],
+                SysArg(
+                    pre_subcmd=SysArg(
+                        pre_subcmd=SysArg(pre_subcmd=None, subcmd=SubCommandLine.Base), subcmd=SubCommandLine.RestServer
+                    ),
+                    subcmd=SubCommandLine.Pull,
                 ),
             ),
         ],

--- a/test/unit_test/model/subcmd_common.py
+++ b/test/unit_test/model/subcmd_common.py
@@ -9,6 +9,7 @@ USE_PYTHON_FILE_RUN_CMD: str = "pyfake.py"
 USE_RELATIVE_PYTHON_FILE_PATH_RUN_CMD: str = "./pyfake.py"
 USE_MORE_RELATIVE_PYTHON_FILE_PATH_RUN_CMD: str = "./test/pyfake.py"
 USE_POETRY_RUN_CMD: str = "/Users/bryant/Library/Caches/pypoetry/virtualenvs/fake-api-server-LE7TJquz-py3.12/bin/fake"
+USE_GITHUB_ACTION_SHELL_RUN_CMD: str = "/opt/hostedtoolcache/Python/3.12.9/x64/bin/fake"
 
 
 class TestSysArg:
@@ -83,6 +84,33 @@ class TestSysArg:
             ),
             (
                 [USE_POETRY_RUN_CMD, "rest-server", "pull", "-h"],
+                SysArg(
+                    pre_subcmd=SysArg(
+                        pre_subcmd=SysArg(pre_subcmd=None, subcmd=SubCommandLine.Base), subcmd=SubCommandLine.RestServer
+                    ),
+                    subcmd=SubCommandLine.Pull,
+                ),
+            ),
+            # run sub-command by GitHub Action environment
+            ([USE_GITHUB_ACTION_SHELL_RUN_CMD, "--help"], SysArg(pre_subcmd=None, subcmd=SubCommandLine.Base)),
+            (
+                [USE_GITHUB_ACTION_SHELL_RUN_CMD, "rest-server", "-h"],
+                SysArg(
+                    pre_subcmd=SysArg(pre_subcmd=None, subcmd=SubCommandLine.Base),
+                    subcmd=SubCommandLine.RestServer,
+                ),
+            ),
+            (
+                [USE_GITHUB_ACTION_SHELL_RUN_CMD, "rest-server", "run", "-h"],
+                SysArg(
+                    pre_subcmd=SysArg(
+                        pre_subcmd=SysArg(pre_subcmd=None, subcmd=SubCommandLine.Base), subcmd=SubCommandLine.RestServer
+                    ),
+                    subcmd=SubCommandLine.Run,
+                ),
+            ),
+            (
+                [USE_GITHUB_ACTION_SHELL_RUN_CMD, "rest-server", "pull", "-h"],
                 SysArg(
                     pre_subcmd=SysArg(
                         pre_subcmd=SysArg(pre_subcmd=None, subcmd=SubCommandLine.Base), subcmd=SubCommandLine.RestServer


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

[//]: # (The summary what you did or your target.)
* ### Task summary:

    Fix the bug about the command line info cannot be parsed in some  runtime environment with specific format.

[//]: # (The task ID in ClickUp [project: https://app.clickup.com/9018752317/v/f/90183126979/90182605225] which maps this change.)
* ### Task tickets:

    * Task ID: CU-86erzzr0c.
    * Relative task IDs: N/A.

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    * Bug point:
        * Cannot use the **_PyFake-API-Server_** command line tool finely in GitHub Action environment without Poetry
        * <img width="963" alt="Screenshot 2025-03-30 at 11 50 44 AM" src="https://github.com/user-attachments/assets/abc3a60a-a7da-496e-83a2-af6ff4ab819a" />
        * The GitHub Action workflow has this bug: https://github.com/Chisanan232/PyFake-API-Server/actions/runs/14151302499/job/39644820348



[//]: # (What's the scope in project it would affect with your modify? For example, would it affect CI workflow? Or any feature usage? Please list all the items which may be affected.)
## _Effecting Scope_

* Fix critical bug without any breaking change.


[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

* Add more test cases to cover the scenarios of this bug.
* Adjust the regular expression to avoid this bug.
