### PR TITLE
[CU-86et3a3pq] Fix the bug about using incorrect git branch of GitHub badge.

### DIFF
--- a/docs/development/contributing/join_in_developing/ci_workflow.md
+++ b/docs/development/contributing/join_in_developing/ci_workflow.md
@@ -172,7 +172,7 @@ Here records all the CI workflows of this project runs.
 ## Documentation CI
 
 [![documentation](https://github.com/Chisanan232/PyFake-API-Server/actions/workflows/documentation.yaml/badge.svg)](https://github.com/Chisanan232/PyFake-API-Server/actions/workflows/documentation.yaml)
-[![pages-build-deployment](https://github.com/Chisanan232/PyFake-API-Server/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/Chisanan232/PyFake-API-Server/actions/workflows/pages/pages-build-deployment)
+[![pages-build-deployment](https://github.com/Chisanan232/PyFake-API-Server/actions/workflows/pages/pages-build-deployment/badge.svg?branch=gh-pages)](https://github.com/Chisanan232/PyFake-API-Server/actions/workflows/pages/pages-build-deployment)
 
 * CI state
 


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

[//]: # (The summary what you did or your target.)
* ### Task summary:

    Fix the bug about using incorrect git branch of GitHub badge.

[//]: # (The task ID in ClickUp [project: https://app.clickup.com/9018752317/v/f/90183126979/90182605225] which maps this change.)
* ### Task tickets:

    * Task ID: CU-86et3a3pq.
    * Relative task IDs: N/A.

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    as is:
        <img width="568" alt="incorrect_github_badge" src="https://github.com/user-attachments/assets/e0e64cb2-7611-4cb3-ae4c-8adbc8ea0310" />
    to be:
        <img width="551" alt="correct_github_badge" src="https://github.com/user-attachments/assets/54cdae14-35f0-4fcc-99e2-933667e6e876" />


[//]: # (What's the scope in project it would affect with your modify? For example, would it affect CI workflow? Or any feature usage? Please list all the items which may be affected.)
## _Effecting Scope_

* Adjust the GitHub badge without other changes.


[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

* Adjust to use correct git branch of the GitHub badge to display the correct CI state.
