### PR TITLE
[CU-86etc7m62] Remove deprecated field in GitHub dependency bot and add new configuration about code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,9 @@
 # Default owners for everything in the repo
 *                               @Chisanan232
 
+# Software license annotation
+/LICENSE                        @Chisanan232
+
 # Core library code
 /fake_api_server/               @Chisanan232
 /fake_api_server/model/         @Chisanan232
@@ -16,6 +19,7 @@
 /test/                          @Chisanan232
 /test/unit_test/                @Chisanan232
 /test/integration_test/         @Chisanan232
+/test/system_test/              @Chisanan232
 
 # Documentation
 /docs/                          @Chisanan232

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,46 @@
+# PyFake-API-Server CODEOWNERS
+# Each line is a file pattern followed by one or more owners.
+
+# Default owners for everything in the repo
+*                               @Chisanan232
+
+# Core library code
+/fake_api_server/               @Chisanan232
+/fake_api_server/model/         @Chisanan232
+/fake_api_server/controller/    @Chisanan232
+
+# API configuration templates
+/fake_api_server/model/api_config/template/    @Chisanan232
+
+# Testing code
+/test/                          @Chisanan232
+/test/unit_test/                @Chisanan232
+/test/integration_test/         @Chisanan232
+
+# Documentation
+/docs/                          @Chisanan232
+*.md                            @Chisanan232
+/mkdocs.yml                     @Chisanan232
+
+# CI/CD and GitHub configuration
+/.github/                       @Chisanan232
+/.github/workflows/             @Chisanan232
+/action.yaml                    @Chisanan232
+
+# Docker configuration
+/Dockerfile*                    @Chisanan232
+/.dockerignore                  @Chisanan232
+
+# Project configuration files
+/pyproject.toml                 @Chisanan232
+/poetry.lock                    @Chisanan232
+/pytest.ini                     @Chisanan232
+/mypy.ini                       @Chisanan232
+/.pylintrc                      @Chisanan232
+/.pre-commit-config.yaml        @Chisanan232
+/.coveragerc                    @Chisanan232
+/codecov.yml                    @Chisanan232
+/sonar-project.properties       @Chisanan232
+
+# Scripts directory
+/scripts/                       @Chisanan232

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    reviewers:
-      - "Chisanan232"
     labels:
       - "🔍 enhancement"
       - "🤖 github actions"
@@ -18,8 +16,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    reviewers:
-      - "Chisanan232"
     labels:
       - "🔍 enhancement"
       - "🐍 python"


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

[//]: # (The summary what you did or your target.)
* ### Task summary:

    Remove deprecated field in GitHub dependency bot and add new configuration about code owners.

[//]: # (The task ID in ClickUp [project: https://app.clickup.com/9018752317/v/f/90183126979/90182605225] which maps this change.)
* ### Task tickets:

    * Task ID: CU-86etc7m62.
    * Relative task IDs:
        * N/A.
    * Relative PRs:
        * N/A.

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/.
    <img width="927" alt="Screenshot 2025-05-06 at 12 03 06 PM" src="https://github.com/user-attachments/assets/da23db3b-378f-4345-8452-3433e7807f98" />


[//]: # (What's the scope in project it would affect with your modify? For example, would it affect CI workflow? Or any feature usage? Please list all the items which may be affected.)
## _Effecting Scope_

* Adjust the configuration only.


[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

* Remove the deprecated field `reviewers` in GitHub dependency bot configuration.
* Add a new configuration about code owners.
